### PR TITLE
ユーザープロフィール機能の実装

### DIFF
--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -39,18 +39,17 @@ class UserController extends Controller
     }
 
     /**
-     *  Followsテーブル一覧と認証ユーザー情報を取得
+     *  認証ユーザー情報とフォローしている人リストを取得
      *
-     * @return array<object, object>
+     * @return array<int, object>
      */
     public function getAuthUserInfo()
     {
-        $follows = Follows::all();
-        $profile = auth()->user();
-
+        $user = auth()->user();
+        $follows = Follows::where('follow_user_id', $user->id)->get('followed_user_id');
         return [
-            "follows" => $follows,
-            "profile" => $profile
+            "userId" => $user->id,
+            "follows" => $follows
         ];
     }
 
@@ -62,7 +61,7 @@ class UserController extends Controller
      */
     public function countFollows(int $userId)
     {
-        return Follows::all()->where('follow_user_id', $userId)->count();
+        return Follows::where('follow_user_id', $userId)->count();
     }
 
     /**
@@ -73,7 +72,7 @@ class UserController extends Controller
      */
     public function countFollowers(int $userId)
     {
-        return Follows::all()->where('followed_user_id', $userId)->count();
+        return Follows::where('followed_user_id', $userId)->count();
     }
 
     /**

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -46,11 +46,11 @@ class UserController extends Controller
     public function getAuthUserInfo()
     {
         $follows = Follows::all();
-        $authuser = auth()->user();
+        $profile = auth()->user();
 
         return [
             "follows" => $follows,
-            "profile" => $authuser
+            "profile" => $profile
         ];
     }
 

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -73,7 +73,7 @@ class UserController extends Controller
      */
     public function countFollowers(int $userId)
     {
-        return Follows::all()->where('follower_user_id', $userId)->count();
+        return Follows::all()->where('followed_user_id', $userId)->count();
     }
 
     /**

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -63,7 +63,6 @@ class UserController extends Controller
     public function countFollows(int $userId)
     {
         return Follows::all()->where('follow_user_id', $userId)->count();
-        //
     }
 
     /**
@@ -75,7 +74,6 @@ class UserController extends Controller
     public function countFollowers(int $userId)
     {
         return Follows::all()->where('follower_user_id', $userId)->count();
-        //
     }
 
     /**

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -50,7 +50,7 @@ class UserController extends Controller
 
         return [
             "follows" => $follows,
-            "authuser" => $authuser
+            "profile" => $authuser
         ];
     }
 

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -7574,10 +7574,22 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
 /* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router/index.js");
 /* harmony import */ var _page_UserList__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./page/UserList */ "./resources/js/components/page/UserList.jsx");
-/* harmony import */ var _css_app_css__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../../css/app.css */ "./resources/css/app.css");
+/* harmony import */ var _page_UserProfile__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./page/UserProfile */ "./resources/js/components/page/UserProfile.jsx");
 /* harmony import */ var _layout_Header__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./layout/Header */ "./resources/js/components/layout/Header.jsx");
-/* harmony import */ var _layout_TweetBtn__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ./layout/TweetBtn */ "./resources/js/components/layout/TweetBtn.jsx");
+/* harmony import */ var _css_app_css__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../../css/app.css */ "./resources/css/app.css");
 /* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
 
 
 
@@ -7588,13 +7600,25 @@ __webpack_require__.r(__webpack_exports__);
 
 
 var App = function App() {
+  //　一覧表示するユーザデータを入れる
+  var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)([]),
+      _useState2 = _slicedToArray(_useState, 2),
+      users = _useState2[0],
+      setUsers = _useState2[1];
+
   return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_7__.BrowserRouter, {
-    children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(_layout_Header__WEBPACK_IMPORTED_MODULE_4__.Header, {}), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_8__.Routes, {
-      children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_8__.Route, {
+    children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(_layout_Header__WEBPACK_IMPORTED_MODULE_4__.Header, {}), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_8__.Routes, {
+      children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_8__.Route, {
         path: "/userList",
-        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(_page_UserList__WEBPACK_IMPORTED_MODULE_2__.UserList, {})
-      })
-    }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(_layout_TweetBtn__WEBPACK_IMPORTED_MODULE_5__.TweetBtn, {})]
+        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(_page_UserList__WEBPACK_IMPORTED_MODULE_2__.UserList, {
+          setUsers: setUsers,
+          users: users
+        })
+      }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_8__.Route, {
+        path: "/profile/:id",
+        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(_page_UserProfile__WEBPACK_IMPORTED_MODULE_3__.UserProfile, {})
+      })]
+    })]
   });
 };
 
@@ -7721,52 +7745,6 @@ var Header = function Header() {
           })]
         })
       })]
-    })
-  });
-};
-
-/***/ }),
-
-/***/ "./resources/js/components/layout/TweetBtn.jsx":
-/*!*****************************************************!*\
-  !*** ./resources/js/components/layout/TweetBtn.jsx ***!
-  \*****************************************************/
-/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
-
-"use strict";
-__webpack_require__.r(__webpack_exports__);
-/* harmony export */ __webpack_require__.d(__webpack_exports__, {
-/* harmony export */   "TweetBtn": () => (/* binding */ TweetBtn)
-/* harmony export */ });
-/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "./node_modules/react/index.js");
-/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
-/* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
-
-
-
-var TweetBtn = function TweetBtn() {
-  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("div", {
-    className: "header__tweetBtn",
-    children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("div", {
-      className: "w-100 h-100 rounded-circle background-twitter",
-      children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_2__.Link, {
-        className: "w-100 h-100",
-        to: "/tweet",
-        children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("div", {
-          className: "w-100 h-100",
-          children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("svg", {
-            className: "header__tweetBtn--icon",
-            fill: "#ffffff",
-            style: {
-              width: 24,
-              height: 24
-            },
-            children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("path", {
-              d: "M8.8 7.2H5.6V3.9c0-.4-.3-.8-.8-.8s-.7.4-.7.8v3.3H.8c-.4 0-.8.3-.8.8s.3.8.8.8h3.3v3.3c0 .4.3.8.8.8s.8-.3.8-.8V8.7H9c.4 0 .8-.3.8-.8s-.5-.7-1-.7zm15-4.9v-.1h-.1c-.1 0-9.2 1.2-14.4 11.7-3.8 7.6-3.6 9.9-3.3 9.9.3.1 3.4-6.5 6.7-9.2 5.2-1.1 6.6-3.6 6.6-3.6s-1.5.2-2.1.2c-.8 0-1.4-.2-1.7-.3 1.3-1.2 2.4-1.5 3.5-1.7.9-.2 1.8-.4 3-1.2 2.2-1.6 1.9-5.5 1.8-5.7z"
-            })
-          })
-        })
-      })
     })
   });
 };
@@ -8007,7 +7985,7 @@ var UserList = function UserList() {
       children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("div", {
         className: "user__item-container",
         children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_6__.Link, {
-          to: "/users/".concat(item.id),
+          to: "/profile/".concat(item.id),
           children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
             className: "d-flex px-2 py-4 w-100",
             children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_UserIcon__WEBPACK_IMPORTED_MODULE_3__.UserIcon, {
@@ -8020,8 +7998,8 @@ var UserList = function UserList() {
                 className: "d-flex justify-content-between",
                 children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_UserName__WEBPACK_IMPORTED_MODULE_4__.UserName, {
                   nameData: {
-                    name: item.screen_name,
-                    id: item.user_name
+                    screen_name: item.screen_name,
+                    user_name: item.user_name
                   }
                 }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_FollowButton__WEBPACK_IMPORTED_MODULE_1__.FollowButton, {
                   userId: item.id,
@@ -8060,6 +8038,289 @@ var UserList = function UserList() {
 
 /***/ }),
 
+/***/ "./resources/js/components/page/UserProfile.jsx":
+/*!******************************************************!*\
+  !*** ./resources/js/components/page/UserProfile.jsx ***!
+  \******************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "UserProfile": () => (/* binding */ UserProfile)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "./node_modules/react/index.js");
+/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router/index.js");
+/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
+/* harmony import */ var _parts_FollowButton__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../parts/FollowButton */ "./resources/js/components/parts/FollowButton.jsx");
+/* harmony import */ var _parts_FollowNumbers__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../parts/FollowNumbers */ "./resources/js/components/parts/FollowNumbers.jsx");
+/* harmony import */ var _parts_UserIcon__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../parts/UserIcon */ "./resources/js/components/parts/UserIcon.jsx");
+/* harmony import */ var _parts_UserName__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ../parts/UserName */ "./resources/js/components/parts/UserName.jsx");
+/* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+
+function _regeneratorRuntime() { "use strict"; /*! regenerator-runtime -- Copyright (c) 2014-present, Facebook, Inc. -- license (MIT): https://github.com/facebook/regenerator/blob/main/LICENSE */ _regeneratorRuntime = function _regeneratorRuntime() { return exports; }; var exports = {}, Op = Object.prototype, hasOwn = Op.hasOwnProperty, $Symbol = "function" == typeof Symbol ? Symbol : {}, iteratorSymbol = $Symbol.iterator || "@@iterator", asyncIteratorSymbol = $Symbol.asyncIterator || "@@asyncIterator", toStringTagSymbol = $Symbol.toStringTag || "@@toStringTag"; function define(obj, key, value) { return Object.defineProperty(obj, key, { value: value, enumerable: !0, configurable: !0, writable: !0 }), obj[key]; } try { define({}, ""); } catch (err) { define = function define(obj, key, value) { return obj[key] = value; }; } function wrap(innerFn, outerFn, self, tryLocsList) { var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator, generator = Object.create(protoGenerator.prototype), context = new Context(tryLocsList || []); return generator._invoke = function (innerFn, self, context) { var state = "suspendedStart"; return function (method, arg) { if ("executing" === state) throw new Error("Generator is already running"); if ("completed" === state) { if ("throw" === method) throw arg; return doneResult(); } for (context.method = method, context.arg = arg;;) { var delegate = context.delegate; if (delegate) { var delegateResult = maybeInvokeDelegate(delegate, context); if (delegateResult) { if (delegateResult === ContinueSentinel) continue; return delegateResult; } } if ("next" === context.method) context.sent = context._sent = context.arg;else if ("throw" === context.method) { if ("suspendedStart" === state) throw state = "completed", context.arg; context.dispatchException(context.arg); } else "return" === context.method && context.abrupt("return", context.arg); state = "executing"; var record = tryCatch(innerFn, self, context); if ("normal" === record.type) { if (state = context.done ? "completed" : "suspendedYield", record.arg === ContinueSentinel) continue; return { value: record.arg, done: context.done }; } "throw" === record.type && (state = "completed", context.method = "throw", context.arg = record.arg); } }; }(innerFn, self, context), generator; } function tryCatch(fn, obj, arg) { try { return { type: "normal", arg: fn.call(obj, arg) }; } catch (err) { return { type: "throw", arg: err }; } } exports.wrap = wrap; var ContinueSentinel = {}; function Generator() {} function GeneratorFunction() {} function GeneratorFunctionPrototype() {} var IteratorPrototype = {}; define(IteratorPrototype, iteratorSymbol, function () { return this; }); var getProto = Object.getPrototypeOf, NativeIteratorPrototype = getProto && getProto(getProto(values([]))); NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol) && (IteratorPrototype = NativeIteratorPrototype); var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype); function defineIteratorMethods(prototype) { ["next", "throw", "return"].forEach(function (method) { define(prototype, method, function (arg) { return this._invoke(method, arg); }); }); } function AsyncIterator(generator, PromiseImpl) { function invoke(method, arg, resolve, reject) { var record = tryCatch(generator[method], generator, arg); if ("throw" !== record.type) { var result = record.arg, value = result.value; return value && "object" == _typeof(value) && hasOwn.call(value, "__await") ? PromiseImpl.resolve(value.__await).then(function (value) { invoke("next", value, resolve, reject); }, function (err) { invoke("throw", err, resolve, reject); }) : PromiseImpl.resolve(value).then(function (unwrapped) { result.value = unwrapped, resolve(result); }, function (error) { return invoke("throw", error, resolve, reject); }); } reject(record.arg); } var previousPromise; this._invoke = function (method, arg) { function callInvokeWithMethodAndArg() { return new PromiseImpl(function (resolve, reject) { invoke(method, arg, resolve, reject); }); } return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg(); }; } function maybeInvokeDelegate(delegate, context) { var method = delegate.iterator[context.method]; if (undefined === method) { if (context.delegate = null, "throw" === context.method) { if (delegate.iterator["return"] && (context.method = "return", context.arg = undefined, maybeInvokeDelegate(delegate, context), "throw" === context.method)) return ContinueSentinel; context.method = "throw", context.arg = new TypeError("The iterator does not provide a 'throw' method"); } return ContinueSentinel; } var record = tryCatch(method, delegate.iterator, context.arg); if ("throw" === record.type) return context.method = "throw", context.arg = record.arg, context.delegate = null, ContinueSentinel; var info = record.arg; return info ? info.done ? (context[delegate.resultName] = info.value, context.next = delegate.nextLoc, "return" !== context.method && (context.method = "next", context.arg = undefined), context.delegate = null, ContinueSentinel) : info : (context.method = "throw", context.arg = new TypeError("iterator result is not an object"), context.delegate = null, ContinueSentinel); } function pushTryEntry(locs) { var entry = { tryLoc: locs[0] }; 1 in locs && (entry.catchLoc = locs[1]), 2 in locs && (entry.finallyLoc = locs[2], entry.afterLoc = locs[3]), this.tryEntries.push(entry); } function resetTryEntry(entry) { var record = entry.completion || {}; record.type = "normal", delete record.arg, entry.completion = record; } function Context(tryLocsList) { this.tryEntries = [{ tryLoc: "root" }], tryLocsList.forEach(pushTryEntry, this), this.reset(!0); } function values(iterable) { if (iterable) { var iteratorMethod = iterable[iteratorSymbol]; if (iteratorMethod) return iteratorMethod.call(iterable); if ("function" == typeof iterable.next) return iterable; if (!isNaN(iterable.length)) { var i = -1, next = function next() { for (; ++i < iterable.length;) { if (hasOwn.call(iterable, i)) return next.value = iterable[i], next.done = !1, next; } return next.value = undefined, next.done = !0, next; }; return next.next = next; } } return { next: doneResult }; } function doneResult() { return { value: undefined, done: !0 }; } return GeneratorFunction.prototype = GeneratorFunctionPrototype, define(Gp, "constructor", GeneratorFunctionPrototype), define(GeneratorFunctionPrototype, "constructor", GeneratorFunction), GeneratorFunction.displayName = define(GeneratorFunctionPrototype, toStringTagSymbol, "GeneratorFunction"), exports.isGeneratorFunction = function (genFun) { var ctor = "function" == typeof genFun && genFun.constructor; return !!ctor && (ctor === GeneratorFunction || "GeneratorFunction" === (ctor.displayName || ctor.name)); }, exports.mark = function (genFun) { return Object.setPrototypeOf ? Object.setPrototypeOf(genFun, GeneratorFunctionPrototype) : (genFun.__proto__ = GeneratorFunctionPrototype, define(genFun, toStringTagSymbol, "GeneratorFunction")), genFun.prototype = Object.create(Gp), genFun; }, exports.awrap = function (arg) { return { __await: arg }; }, defineIteratorMethods(AsyncIterator.prototype), define(AsyncIterator.prototype, asyncIteratorSymbol, function () { return this; }), exports.AsyncIterator = AsyncIterator, exports.async = function (innerFn, outerFn, self, tryLocsList, PromiseImpl) { void 0 === PromiseImpl && (PromiseImpl = Promise); var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList), PromiseImpl); return exports.isGeneratorFunction(outerFn) ? iter : iter.next().then(function (result) { return result.done ? result.value : iter.next(); }); }, defineIteratorMethods(Gp), define(Gp, toStringTagSymbol, "Generator"), define(Gp, iteratorSymbol, function () { return this; }), define(Gp, "toString", function () { return "[object Generator]"; }), exports.keys = function (object) { var keys = []; for (var key in object) { keys.push(key); } return keys.reverse(), function next() { for (; keys.length;) { var key = keys.pop(); if (key in object) return next.value = key, next.done = !1, next; } return next.done = !0, next; }; }, exports.values = values, Context.prototype = { constructor: Context, reset: function reset(skipTempReset) { if (this.prev = 0, this.next = 0, this.sent = this._sent = undefined, this.done = !1, this.delegate = null, this.method = "next", this.arg = undefined, this.tryEntries.forEach(resetTryEntry), !skipTempReset) for (var name in this) { "t" === name.charAt(0) && hasOwn.call(this, name) && !isNaN(+name.slice(1)) && (this[name] = undefined); } }, stop: function stop() { this.done = !0; var rootRecord = this.tryEntries[0].completion; if ("throw" === rootRecord.type) throw rootRecord.arg; return this.rval; }, dispatchException: function dispatchException(exception) { if (this.done) throw exception; var context = this; function handle(loc, caught) { return record.type = "throw", record.arg = exception, context.next = loc, caught && (context.method = "next", context.arg = undefined), !!caught; } for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i], record = entry.completion; if ("root" === entry.tryLoc) return handle("end"); if (entry.tryLoc <= this.prev) { var hasCatch = hasOwn.call(entry, "catchLoc"), hasFinally = hasOwn.call(entry, "finallyLoc"); if (hasCatch && hasFinally) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } else if (hasCatch) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); } else { if (!hasFinally) throw new Error("try statement without catch or finally"); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } } } }, abrupt: function abrupt(type, arg) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc <= this.prev && hasOwn.call(entry, "finallyLoc") && this.prev < entry.finallyLoc) { var finallyEntry = entry; break; } } finallyEntry && ("break" === type || "continue" === type) && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc && (finallyEntry = null); var record = finallyEntry ? finallyEntry.completion : {}; return record.type = type, record.arg = arg, finallyEntry ? (this.method = "next", this.next = finallyEntry.finallyLoc, ContinueSentinel) : this.complete(record); }, complete: function complete(record, afterLoc) { if ("throw" === record.type) throw record.arg; return "break" === record.type || "continue" === record.type ? this.next = record.arg : "return" === record.type ? (this.rval = this.arg = record.arg, this.method = "return", this.next = "end") : "normal" === record.type && afterLoc && (this.next = afterLoc), ContinueSentinel; }, finish: function finish(finallyLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.finallyLoc === finallyLoc) return this.complete(entry.completion, entry.afterLoc), resetTryEntry(entry), ContinueSentinel; } }, "catch": function _catch(tryLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc === tryLoc) { var record = entry.completion; if ("throw" === record.type) { var thrown = record.arg; resetTryEntry(entry); } return thrown; } } throw new Error("illegal catch attempt"); }, delegateYield: function delegateYield(iterable, resultName, nextLoc) { return this.delegate = { iterator: values(iterable), resultName: resultName, nextLoc: nextLoc }, "next" === this.method && (this.arg = undefined), ContinueSentinel; } }, exports; }
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+
+
+
+
+
+
+
+
+var UserProfile = function UserProfile() {
+  var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)([]),
+      _useState2 = _slicedToArray(_useState, 2),
+      authUserFollows = _useState2[0],
+      setAuthUserFollows = _useState2[1];
+
+  var _useState3 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)({}),
+      _useState4 = _slicedToArray(_useState3, 2),
+      user = _useState4[0],
+      setUser = _useState4[1];
+
+  var _useState5 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(false),
+      _useState6 = _slicedToArray(_useState5, 2),
+      isFollowing = _useState6[0],
+      setIsFollowing = _useState6[1];
+
+  var _useState7 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(false),
+      _useState8 = _slicedToArray(_useState7, 2),
+      isAuth = _useState8[0],
+      setIsAuth = _useState8[1]; // ユーザーIDの取得
+
+
+  var _useParams = (0,react_router_dom__WEBPACK_IMPORTED_MODULE_6__.useParams)(),
+      id = _useParams.id; // csrf対策のため、トークンを取得
+
+
+  var csrf_token = document.querySelector('meta[name="csrf-token"]').content; // /authuser 認証ユーザーの情報取得
+
+  var getAuthUserData = /*#__PURE__*/function () {
+    var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
+      var res, authUserData;
+      return _regeneratorRuntime().wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              _context.next = 2;
+              return fetch("/authuser", {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  "X-CSRF-TOKEN": csrf_token
+                }
+              });
+
+            case 2:
+              res = _context.sent;
+
+              if (!(res.status === 200)) {
+                _context.next = 9;
+                break;
+              }
+
+              _context.next = 6;
+              return res.json();
+
+            case 6:
+              authUserData = _context.sent;
+              console.log(authUserData);
+              return _context.abrupt("return", authUserData);
+
+            case 9:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee);
+    }));
+
+    return function getAuthUserData() {
+      return _ref.apply(this, arguments);
+    };
+  }(); // 認証ユーザーがフォローしているユーザ一覧を配列でsetAuthUserFollowsにセット
+
+
+  var checkAuthUserFollows = function checkAuthUserFollows(authUserFollows, authUserId) {
+    var authUserFollowsList = authUserFollows.filter(function (data) {
+      return Number(data["follow_user_id"]) === authUserId;
+    }).map(function (data) {
+      return Number(data["followed_user_id"]);
+    });
+    setAuthUserFollows(authUserFollowsList);
+  }; // 認証ユーザーがフォローしているユーザーリストをauthUserFollowsにセットする
+
+
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
+    // 認証ユーザーのプロフィールとフォロー関係データを呼び出す
+    getAuthUserData().then(function (authUserData) {
+      setIsAuth(authUserData.authuser.id === Number(id));
+      checkAuthUserFollows(authUserData.follows, authUserData.authuser.id);
+    });
+  }, []);
+
+  var getUserProfile = /*#__PURE__*/function () {
+    var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2() {
+      var res, userProfile;
+      return _regeneratorRuntime().wrap(function _callee2$(_context2) {
+        while (1) {
+          switch (_context2.prev = _context2.next) {
+            case 0:
+              _context2.next = 2;
+              return fetch("/user/".concat(id));
+
+            case 2:
+              res = _context2.sent;
+
+              if (!(res.status === 200)) {
+                _context2.next = 9;
+                break;
+              }
+
+              _context2.next = 6;
+              return res.json();
+
+            case 6:
+              userProfile = _context2.sent;
+              setIsFollowing(authUserFollows.includes(Number(id)));
+              setUser(userProfile);
+
+            case 9:
+            case "end":
+              return _context2.stop();
+          }
+        }
+      }, _callee2);
+    }));
+
+    return function getUserProfile() {
+      return _ref2.apply(this, arguments);
+    };
+  }();
+
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
+    getUserProfile();
+  }, [authUserFollows]);
+
+  var profileButton = function profileButton() {
+    if (isAuth) {
+      return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("button", {
+        type: "button",
+        className: "btn btn-outline-dark",
+        children: "\u7DE8\u96C6"
+      });
+    } else {
+      return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_FollowButton__WEBPACK_IMPORTED_MODULE_1__.FollowButton, {
+        userId: id,
+        user: user,
+        isFollowing: isFollowing
+      });
+    }
+  };
+
+  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
+    className: "container-lg mt-5",
+    children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
+      className: "border",
+      children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
+        onClick: function onClick() {
+          return console.log(isFollowing);
+        },
+        children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
+          className: "d-flex p-1",
+          children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_7__.Link, {
+            to: "/userlist",
+            children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("button", {
+              className: "btn",
+              children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("svg", {
+                viewBox: "0 0 16 16",
+                width: "16",
+                height: "16",
+                xmlns: "http://www.w3.org/2000/svg",
+                fill: "#111111",
+                className: "bi bi-arrow-left",
+                children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("path", {
+                  d: "M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z"
+                })
+              })
+            })
+          }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("div", {
+            className: "me-3",
+            children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("h2", {
+              children: user.screen_name
+            })
+          })]
+        }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("div", {
+          children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("img", {
+            className: "w-100 bg-primary",
+            style: {
+              height: "160px"
+            },
+            src: "/images/twitter-cover-example.png",
+            alt: "\u30D7\u30ED\u30D5\u30A3\u30FC\u30EB \u30AB\u30D0\u30FC\u753B\u50CF"
+          })
+        })]
+      }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
+        className: "p-3",
+        children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
+          className: "position-relative",
+          children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("div", {
+            className: "w-100 d-flex justify-content-end",
+            children: profileButton()
+          }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_UserIcon__WEBPACK_IMPORTED_MODULE_3__.UserIcon, {
+            userList: false,
+            iconData: {
+              icon: user.icon,
+              desc: user.iconDesc
+            }
+          })]
+        }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
+          children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_UserName__WEBPACK_IMPORTED_MODULE_4__.UserName, {
+            isUserProfile: true,
+            nameData: {
+              screen_name: user.screen_name,
+              user_name: user.user_name
+            }
+          }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("div", {
+            className: "mt-1",
+            children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("p", {
+              children: user.profile
+            })
+          })]
+        }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_FollowNumbers__WEBPACK_IMPORTED_MODULE_2__.FollowNumbers, {
+          userId: id,
+          isAuth: isAuth
+        })]
+      })]
+    }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("div", {
+      className: "border",
+      children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("p", {
+        children: "\u30C4\u30A4\u30FC\u30C8\u4E00\u89A7"
+      })
+    })]
+  });
+};
+
+/***/ }),
+
 /***/ "./resources/js/components/parts/FollowButton.jsx":
 /*!********************************************************!*\
   !*** ./resources/js/components/parts/FollowButton.jsx ***!
@@ -8087,7 +8348,6 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 
-
 var FollowButton = function FollowButton(props) {
   var userId = props.userId,
       isFollowing = props.isFollowing,
@@ -8100,10 +8360,8 @@ var FollowButton = function FollowButton(props) {
       setFollowStatus = _useState2[1];
 
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
-    // console.log("isFollowing");
-    // console.log(isFollowing);
     setFollowStatus(isFollowing);
-  }, [users, authUserfollows]); // csrf対策のため、トークンを取得
+  }, [users, isFollowing]); // csrf対策のため、トークンを取得
 
   var csrf_token = document.querySelector('meta[name="csrf-token"]').content;
   var options = {
@@ -8128,16 +8386,69 @@ var FollowButton = function FollowButton(props) {
     });
   };
 
-  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)(react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.Fragment, {
-    children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("button", {
-      type: "button",
-      className: "btn ".concat(followStatus ? "btn-dark" : "btn-outline-dark"),
-      onClick: followStatus ? function (e) {
-        return unfollowUser(e);
-      } : function (e) {
-        return followUser(e);
-      },
-      children: followStatus ? "フォロー解除" : "フォロー"
+  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("button", {
+    type: "button",
+    className: "btn ".concat(followStatus ? "btn-dark" : "btn-outline-dark"),
+    onClick: followStatus ? function (e) {
+      return unfollowUser(e);
+    } : function (e) {
+      return followUser(e);
+    },
+    children: followStatus ? "フォロー解除" : "フォロー"
+  });
+};
+
+/***/ }),
+
+/***/ "./resources/js/components/parts/FollowNumbers.jsx":
+/*!*********************************************************!*\
+  !*** ./resources/js/components/parts/FollowNumbers.jsx ***!
+  \*********************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "FollowNumbers": () => (/* binding */ FollowNumbers)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "./node_modules/react/index.js");
+/* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
+
+
+
+var FollowNumbers = function FollowNumbers(props) {
+  // id: 表示ユーザー authUserId: ログインしているユーザー
+  var userId = props.userId,
+      isAuth = props.isAuth;
+  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("div", {
+    className: "mt-1",
+    children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsxs)("div", {
+      className: "d-flex",
+      children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("div", {
+        children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsxs)("button", {
+          className: "d-flex",
+          type: "button",
+          children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("span", {
+            className: "fw-bold",
+            children: "100"
+          }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("p", {
+            className: "ms-1",
+            children: "\u30D5\u30A9\u30ED\u30FC"
+          })]
+        })
+      }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("div", {
+        children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsxs)("button", {
+          className: "d-flex ms-3",
+          type: "button",
+          children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("span", {
+            className: "fw-bold",
+            children: "110"
+          }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("p", {
+            className: "ms-1",
+            children: "\u30D5\u30A9\u30ED\u30EF\u30FC"
+          })]
+        })
+      })]
     })
   });
 };
@@ -8313,14 +8624,16 @@ __webpack_require__.r(__webpack_exports__);
 
 
 var UserName = function UserName(props) {
+  var isUserDetail = props.isUserDetail,
+      nameData = props.nameData;
   return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsxs)("div", {
-    className: "".concat(props.isUserDetail ? "mt-2" : ""),
+    className: "".concat(isUserDetail ? "mt-2" : ""),
     children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("p", {
-      className: "lh-sm fw-bold ".concat(props.isUserDetail ? "fs-4" : ""),
-      children: props.nameData.name
+      className: "lh-sm fw-bold ".concat(isUserDetail ? "fs-4" : ""),
+      children: nameData.screen_name
     }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsxs)("span", {
       className: "opacity-50",
-      children: ["\uFF20", props.nameData.id]
+      children: ["\uFF20", nameData.user_name]
     })]
   });
 };

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -7819,7 +7819,7 @@ var UserList = function UserList() {
 
   var getAuthUserData = /*#__PURE__*/function () {
     var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
-      var res, authUser;
+      var res, authUserData;
       return _regeneratorRuntime().wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
@@ -7845,8 +7845,8 @@ var UserList = function UserList() {
               return res.json();
 
             case 6:
-              authUser = _context.sent;
-              return _context.abrupt("return", authUser);
+              authUserData = _context.sent;
+              return _context.abrupt("return", authUserData);
 
             case 8:
             case "end":
@@ -7859,14 +7859,12 @@ var UserList = function UserList() {
     return function getAuthUserData() {
       return _ref.apply(this, arguments);
     };
-  }(); // 認証ユーザーがフォローしているユーザ一覧を配列でsetAuthUserFollowsにセット
+  }(); // 認証ユーザーがフォローしているリストを配列でsetAuthUserFollowsにセット
 
 
-  var checkAuthUserFollows = function checkAuthUserFollows(authUserFollows, authUserId) {
-    var authUserFollowsList = authUserFollows.filter(function (data) {
-      return Number(data["follow_user_id"]) === authUserId;
-    }).map(function (data) {
-      return Number(data["followed_user_id"]);
+  var checkAuthUserFollows = function checkAuthUserFollows(authUserFollows) {
+    var authUserFollowsList = authUserFollows.map(function (data) {
+      return Number(data.followed_user_id);
     });
     setAuthUserFollows(authUserFollowsList);
   }; // 認証ユーザーがフォローしているユーザーリストをauthUserFollowsにセットする
@@ -7874,8 +7872,8 @@ var UserList = function UserList() {
 
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
     // 認証ユーザーのプロフィールとフォロー関係データを呼び出す
-    getAuthUserData().then(function (authUser) {
-      checkAuthUserFollows(authUser.follows, authUser.profile.id);
+    getAuthUserData().then(function (authUserData) {
+      checkAuthUserFollows(authUserData.follows);
     });
   }, []);
 
@@ -7985,7 +7983,7 @@ var UserList = function UserList() {
       children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("div", {
         className: "user__item-container",
         children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_6__.Link, {
-          to: "/profile/".concat(item.id),
+          to: "/profile-".concat(item.id),
           children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
             className: "d-flex px-2 py-4 w-100",
             children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_UserIcon__WEBPACK_IMPORTED_MODULE_3__.UserIcon, {
@@ -8115,7 +8113,7 @@ var UserProfile = function UserProfile() {
 
   var getAuthUserData = /*#__PURE__*/function () {
     var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
-      var res, authUser;
+      var res, authUserData;
       return _regeneratorRuntime().wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
@@ -8141,8 +8139,8 @@ var UserProfile = function UserProfile() {
               return res.json();
 
             case 6:
-              authUser = _context.sent;
-              return _context.abrupt("return", authUser);
+              authUserData = _context.sent;
+              return _context.abrupt("return", authUserData);
 
             case 8:
             case "end":
@@ -8158,23 +8156,21 @@ var UserProfile = function UserProfile() {
   }(); // 認証ユーザーがフォローしているユーザ一覧を配列でsetAuthUserFollowsにセット
 
 
-  var checkAuthUserFollows = function checkAuthUserFollows(authUserFollowsList, authUserId) {
-    var authUserFollows = authUserFollowsList.filter(function (data) {
-      return Number(data["follow_user_id"]) === authUserId;
-    }).map(function (data) {
-      return Number(data["followed_user_id"]);
+  var checkAuthUserFollows = function checkAuthUserFollows(authUserFollows) {
+    var authUserFollowsList = authUserFollows.map(function (data) {
+      return Number(data.followed_user_id);
     });
-    setAuthUserFollows(authUserFollows);
-  };
+    setAuthUserFollows(authUserFollowsList);
+  }; // 認証ユーザーがフォローしているユーザーリストをauthUserFollowsにセットする
+
 
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
-    getAuthUserData().then(function (authUser) {
-      // 認証ユーザーか確認
-      setIsAuth(authUser.profile.id === Number(id)); // 認証ユーザーがフォローしているか確認
-
-      checkAuthUserFollows(authUser.follows, authUser.profile.id);
+    // 認証ユーザーのプロフィールとフォロー関係データを呼び出す
+    getAuthUserData().then(function (authUserData) {
+      setIsAuth(authUserData.userId === Number(id));
+      checkAuthUserFollows(authUserData.follows);
     });
-  }, []); // 表示するユーザープロフィールをセット
+  }, []);
 
   var getUserProfile = /*#__PURE__*/function () {
     var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2() {
@@ -8184,7 +8180,7 @@ var UserProfile = function UserProfile() {
           switch (_context2.prev = _context2.next) {
             case 0:
               _context2.next = 2;
-              return fetch("/user/".concat(id));
+              return fetch("/user-".concat(id));
 
             case 2:
               res = _context2.sent;
@@ -8217,7 +8213,7 @@ var UserProfile = function UserProfile() {
 
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
     getUserProfile();
-  }, [authUserFollows]); // 認証ユーザーとそうでない場合でボタンを切り替え
+  }, [authUserFollows]);
 
   var profileButton = function profileButton() {
     if (isAuth) {
@@ -8305,7 +8301,8 @@ var UserProfile = function UserProfile() {
             })
           })]
         }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_FollowNumbers__WEBPACK_IMPORTED_MODULE_2__.FollowNumbers, {
-          userId: id
+          userId: id,
+          isAuth: isAuth
         })]
       })]
     }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("div", {
@@ -8372,14 +8369,14 @@ var FollowButton = function FollowButton(props) {
 
   var followUser = function followUser(e) {
     e.preventDefault();
-    fetch("/follow/".concat(userId), options).then(function () {
+    fetch("/follow-".concat(userId), options).then(function () {
       setFollowStatus(true);
     });
   };
 
   var unfollowUser = function unfollowUser(e) {
     e.preventDefault();
-    fetch("/unfollow/".concat(userId), options).then(function () {
+    fetch("/unfollow-".concat(userId), options).then(function () {
       return setFollowStatus(false);
     });
   };
@@ -8457,7 +8454,7 @@ var FollowNumbers = function FollowNumbers(props) {
           switch (_context.prev = _context.next) {
             case 0:
               _context.next = 2;
-              return fetch("/countFollows/".concat(userId));
+              return fetch("/countFollows-".concat(userId));
 
             case 2:
               res = _context.sent;
@@ -8496,7 +8493,7 @@ var FollowNumbers = function FollowNumbers(props) {
           switch (_context2.prev = _context2.next) {
             case 0:
               _context2.next = 2;
-              return fetch("/countFollowers/".concat(userId));
+              return fetch("/countFollowers-".concat(userId));
 
             case 2:
               res = _context2.sent;

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -8454,7 +8454,7 @@ var FollowNumbers = function FollowNumbers(props) {
           switch (_context.prev = _context.next) {
             case 0:
               _context.next = 2;
-              return fetch("/countFollows-".concat(userId));
+              return fetch("/count-follows/".concat(userId));
 
             case 2:
               res = _context.sent;
@@ -8493,7 +8493,7 @@ var FollowNumbers = function FollowNumbers(props) {
           switch (_context2.prev = _context2.next) {
             case 0:
               _context2.next = 2;
-              return fetch("/countFollowers-".concat(userId));
+              return fetch("/count-followers/".concat(userId));
 
             case 2:
               res = _context2.sent;

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -8306,8 +8306,7 @@ var UserProfile = function UserProfile() {
             })
           })]
         }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_FollowNumbers__WEBPACK_IMPORTED_MODULE_2__.FollowNumbers, {
-          userId: id,
-          isAuth: isAuth
+          userId: id
         })]
       })]
     }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("div", {
@@ -8421,73 +8420,118 @@ function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try
 
 function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
 
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
 
 
 
 var FollowNumbers = function FollowNumbers(props) {
   // id: 表示ユーザー authUserId: ログインしているユーザー
-  var userId = props.userId,
-      isAuth = props.isAuth;
+  var userId = props.userId;
 
   var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
-      follows = _useState.follows,
-      setFollows = _useState.setFollows;
+      _useState2 = _slicedToArray(_useState, 2),
+      follows = _useState2[0],
+      setFollows = _useState2[1];
 
-  var _useState2 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
-      followers = _useState2.followers,
-      setFollowers = _useState2.setFollowers; //フォロー数を取得
+  var _useState3 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
+      _useState4 = _slicedToArray(_useState3, 2),
+      followers = _useState4[0],
+      setFollowers = _useState4[1]; //フォロー数を取得
 
 
-  var getFollowsNumber = (0,react__WEBPACK_IMPORTED_MODULE_0__.useCallback)( /*#__PURE__*/_asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
-    var res, followsNum;
-    return _regeneratorRuntime().wrap(function _callee$(_context) {
-      while (1) {
-        switch (_context.prev = _context.next) {
-          case 0:
-            _context.next = 2;
-            return fetch("/countFollows/".concat(userId));
+  var getFollowsNumber = /*#__PURE__*/function () {
+    var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
+      var res, followsNum;
+      return _regeneratorRuntime().wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              _context.next = 2;
+              return fetch("/countFollows/".concat(userId));
 
-          case 2:
-            res = _context.sent;
+            case 2:
+              res = _context.sent;
 
-            if (!(res.status === 200)) {
-              _context.next = 9;
-              break;
-            }
+              if (!(res.status === 200)) {
+                _context.next = 9;
+                break;
+              }
 
-            _context.next = 6;
-            return res.json();
+              _context.next = 6;
+              return res.json();
 
-          case 6:
-            followsNum = _context.sent;
-            console.log(followsNum);
-            setFollows(followsNum);
+            case 6:
+              followsNum = _context.sent;
+              console.log(followsNum);
+              setFollows(followsNum);
 
-          case 9:
-          case "end":
-            return _context.stop();
+            case 9:
+            case "end":
+              return _context.stop();
+          }
         }
-      }
-    }, _callee);
-  })));
-  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
-    console.log(userId);
-    getFollowsNumber();
+      }, _callee);
+    }));
 
-    var cleanup = function cleanup() {
-      console.log("cleanup!");
+    return function getFollowsNumber() {
+      return _ref.apply(this, arguments);
     };
+  }();
 
-    return cleanup;
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
+    getFollowsNumber();
+    getFollowersNumber();
   }, []); // フォロワー数を取得
-  // const getFollowersNumber = async () => {
-  //     const res = await fetch(`/countFollowers/${userId}`);
-  //     if (res.status === 200) {
-  //         const followersNum = await res.json();
-  //         console.log(followersNum);
-  //         return followersNum;
-  //     }
-  // };
+
+  var getFollowersNumber = /*#__PURE__*/function () {
+    var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2() {
+      var res, followersNum;
+      return _regeneratorRuntime().wrap(function _callee2$(_context2) {
+        while (1) {
+          switch (_context2.prev = _context2.next) {
+            case 0:
+              _context2.next = 2;
+              return fetch("/countFollowers/".concat(userId));
+
+            case 2:
+              res = _context2.sent;
+
+              if (!(res.status === 200)) {
+                _context2.next = 9;
+                break;
+              }
+
+              _context2.next = 6;
+              return res.json();
+
+            case 6:
+              followersNum = _context2.sent;
+              console.log(followersNum);
+              setFollowers(followersNum);
+
+            case 9:
+            case "end":
+              return _context2.stop();
+          }
+        }
+      }, _callee2);
+    }));
+
+    return function getFollowersNumber() {
+      return _ref2.apply(this, arguments);
+    };
+  }();
 
   return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("div", {
     className: "mt-1",

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -8413,6 +8413,14 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ });
 /* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 /* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+
+function _regeneratorRuntime() { "use strict"; /*! regenerator-runtime -- Copyright (c) 2014-present, Facebook, Inc. -- license (MIT): https://github.com/facebook/regenerator/blob/main/LICENSE */ _regeneratorRuntime = function _regeneratorRuntime() { return exports; }; var exports = {}, Op = Object.prototype, hasOwn = Op.hasOwnProperty, $Symbol = "function" == typeof Symbol ? Symbol : {}, iteratorSymbol = $Symbol.iterator || "@@iterator", asyncIteratorSymbol = $Symbol.asyncIterator || "@@asyncIterator", toStringTagSymbol = $Symbol.toStringTag || "@@toStringTag"; function define(obj, key, value) { return Object.defineProperty(obj, key, { value: value, enumerable: !0, configurable: !0, writable: !0 }), obj[key]; } try { define({}, ""); } catch (err) { define = function define(obj, key, value) { return obj[key] = value; }; } function wrap(innerFn, outerFn, self, tryLocsList) { var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator, generator = Object.create(protoGenerator.prototype), context = new Context(tryLocsList || []); return generator._invoke = function (innerFn, self, context) { var state = "suspendedStart"; return function (method, arg) { if ("executing" === state) throw new Error("Generator is already running"); if ("completed" === state) { if ("throw" === method) throw arg; return doneResult(); } for (context.method = method, context.arg = arg;;) { var delegate = context.delegate; if (delegate) { var delegateResult = maybeInvokeDelegate(delegate, context); if (delegateResult) { if (delegateResult === ContinueSentinel) continue; return delegateResult; } } if ("next" === context.method) context.sent = context._sent = context.arg;else if ("throw" === context.method) { if ("suspendedStart" === state) throw state = "completed", context.arg; context.dispatchException(context.arg); } else "return" === context.method && context.abrupt("return", context.arg); state = "executing"; var record = tryCatch(innerFn, self, context); if ("normal" === record.type) { if (state = context.done ? "completed" : "suspendedYield", record.arg === ContinueSentinel) continue; return { value: record.arg, done: context.done }; } "throw" === record.type && (state = "completed", context.method = "throw", context.arg = record.arg); } }; }(innerFn, self, context), generator; } function tryCatch(fn, obj, arg) { try { return { type: "normal", arg: fn.call(obj, arg) }; } catch (err) { return { type: "throw", arg: err }; } } exports.wrap = wrap; var ContinueSentinel = {}; function Generator() {} function GeneratorFunction() {} function GeneratorFunctionPrototype() {} var IteratorPrototype = {}; define(IteratorPrototype, iteratorSymbol, function () { return this; }); var getProto = Object.getPrototypeOf, NativeIteratorPrototype = getProto && getProto(getProto(values([]))); NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol) && (IteratorPrototype = NativeIteratorPrototype); var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype); function defineIteratorMethods(prototype) { ["next", "throw", "return"].forEach(function (method) { define(prototype, method, function (arg) { return this._invoke(method, arg); }); }); } function AsyncIterator(generator, PromiseImpl) { function invoke(method, arg, resolve, reject) { var record = tryCatch(generator[method], generator, arg); if ("throw" !== record.type) { var result = record.arg, value = result.value; return value && "object" == _typeof(value) && hasOwn.call(value, "__await") ? PromiseImpl.resolve(value.__await).then(function (value) { invoke("next", value, resolve, reject); }, function (err) { invoke("throw", err, resolve, reject); }) : PromiseImpl.resolve(value).then(function (unwrapped) { result.value = unwrapped, resolve(result); }, function (error) { return invoke("throw", error, resolve, reject); }); } reject(record.arg); } var previousPromise; this._invoke = function (method, arg) { function callInvokeWithMethodAndArg() { return new PromiseImpl(function (resolve, reject) { invoke(method, arg, resolve, reject); }); } return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg(); }; } function maybeInvokeDelegate(delegate, context) { var method = delegate.iterator[context.method]; if (undefined === method) { if (context.delegate = null, "throw" === context.method) { if (delegate.iterator["return"] && (context.method = "return", context.arg = undefined, maybeInvokeDelegate(delegate, context), "throw" === context.method)) return ContinueSentinel; context.method = "throw", context.arg = new TypeError("The iterator does not provide a 'throw' method"); } return ContinueSentinel; } var record = tryCatch(method, delegate.iterator, context.arg); if ("throw" === record.type) return context.method = "throw", context.arg = record.arg, context.delegate = null, ContinueSentinel; var info = record.arg; return info ? info.done ? (context[delegate.resultName] = info.value, context.next = delegate.nextLoc, "return" !== context.method && (context.method = "next", context.arg = undefined), context.delegate = null, ContinueSentinel) : info : (context.method = "throw", context.arg = new TypeError("iterator result is not an object"), context.delegate = null, ContinueSentinel); } function pushTryEntry(locs) { var entry = { tryLoc: locs[0] }; 1 in locs && (entry.catchLoc = locs[1]), 2 in locs && (entry.finallyLoc = locs[2], entry.afterLoc = locs[3]), this.tryEntries.push(entry); } function resetTryEntry(entry) { var record = entry.completion || {}; record.type = "normal", delete record.arg, entry.completion = record; } function Context(tryLocsList) { this.tryEntries = [{ tryLoc: "root" }], tryLocsList.forEach(pushTryEntry, this), this.reset(!0); } function values(iterable) { if (iterable) { var iteratorMethod = iterable[iteratorSymbol]; if (iteratorMethod) return iteratorMethod.call(iterable); if ("function" == typeof iterable.next) return iterable; if (!isNaN(iterable.length)) { var i = -1, next = function next() { for (; ++i < iterable.length;) { if (hasOwn.call(iterable, i)) return next.value = iterable[i], next.done = !1, next; } return next.value = undefined, next.done = !0, next; }; return next.next = next; } } return { next: doneResult }; } function doneResult() { return { value: undefined, done: !0 }; } return GeneratorFunction.prototype = GeneratorFunctionPrototype, define(Gp, "constructor", GeneratorFunctionPrototype), define(GeneratorFunctionPrototype, "constructor", GeneratorFunction), GeneratorFunction.displayName = define(GeneratorFunctionPrototype, toStringTagSymbol, "GeneratorFunction"), exports.isGeneratorFunction = function (genFun) { var ctor = "function" == typeof genFun && genFun.constructor; return !!ctor && (ctor === GeneratorFunction || "GeneratorFunction" === (ctor.displayName || ctor.name)); }, exports.mark = function (genFun) { return Object.setPrototypeOf ? Object.setPrototypeOf(genFun, GeneratorFunctionPrototype) : (genFun.__proto__ = GeneratorFunctionPrototype, define(genFun, toStringTagSymbol, "GeneratorFunction")), genFun.prototype = Object.create(Gp), genFun; }, exports.awrap = function (arg) { return { __await: arg }; }, defineIteratorMethods(AsyncIterator.prototype), define(AsyncIterator.prototype, asyncIteratorSymbol, function () { return this; }), exports.AsyncIterator = AsyncIterator, exports.async = function (innerFn, outerFn, self, tryLocsList, PromiseImpl) { void 0 === PromiseImpl && (PromiseImpl = Promise); var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList), PromiseImpl); return exports.isGeneratorFunction(outerFn) ? iter : iter.next().then(function (result) { return result.done ? result.value : iter.next(); }); }, defineIteratorMethods(Gp), define(Gp, toStringTagSymbol, "Generator"), define(Gp, iteratorSymbol, function () { return this; }), define(Gp, "toString", function () { return "[object Generator]"; }), exports.keys = function (object) { var keys = []; for (var key in object) { keys.push(key); } return keys.reverse(), function next() { for (; keys.length;) { var key = keys.pop(); if (key in object) return next.value = key, next.done = !1, next; } return next.done = !0, next; }; }, exports.values = values, Context.prototype = { constructor: Context, reset: function reset(skipTempReset) { if (this.prev = 0, this.next = 0, this.sent = this._sent = undefined, this.done = !1, this.delegate = null, this.method = "next", this.arg = undefined, this.tryEntries.forEach(resetTryEntry), !skipTempReset) for (var name in this) { "t" === name.charAt(0) && hasOwn.call(this, name) && !isNaN(+name.slice(1)) && (this[name] = undefined); } }, stop: function stop() { this.done = !0; var rootRecord = this.tryEntries[0].completion; if ("throw" === rootRecord.type) throw rootRecord.arg; return this.rval; }, dispatchException: function dispatchException(exception) { if (this.done) throw exception; var context = this; function handle(loc, caught) { return record.type = "throw", record.arg = exception, context.next = loc, caught && (context.method = "next", context.arg = undefined), !!caught; } for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i], record = entry.completion; if ("root" === entry.tryLoc) return handle("end"); if (entry.tryLoc <= this.prev) { var hasCatch = hasOwn.call(entry, "catchLoc"), hasFinally = hasOwn.call(entry, "finallyLoc"); if (hasCatch && hasFinally) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } else if (hasCatch) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); } else { if (!hasFinally) throw new Error("try statement without catch or finally"); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } } } }, abrupt: function abrupt(type, arg) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc <= this.prev && hasOwn.call(entry, "finallyLoc") && this.prev < entry.finallyLoc) { var finallyEntry = entry; break; } } finallyEntry && ("break" === type || "continue" === type) && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc && (finallyEntry = null); var record = finallyEntry ? finallyEntry.completion : {}; return record.type = type, record.arg = arg, finallyEntry ? (this.method = "next", this.next = finallyEntry.finallyLoc, ContinueSentinel) : this.complete(record); }, complete: function complete(record, afterLoc) { if ("throw" === record.type) throw record.arg; return "break" === record.type || "continue" === record.type ? this.next = record.arg : "return" === record.type ? (this.rval = this.arg = record.arg, this.method = "return", this.next = "end") : "normal" === record.type && afterLoc && (this.next = afterLoc), ContinueSentinel; }, finish: function finish(finallyLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.finallyLoc === finallyLoc) return this.complete(entry.completion, entry.afterLoc), resetTryEntry(entry), ContinueSentinel; } }, "catch": function _catch(tryLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc === tryLoc) { var record = entry.completion; if ("throw" === record.type) { var thrown = record.arg; resetTryEntry(entry); } return thrown; } } throw new Error("illegal catch attempt"); }, delegateYield: function delegateYield(iterable, resultName, nextLoc) { return this.delegate = { iterator: values(iterable), resultName: resultName, nextLoc: nextLoc }, "next" === this.method && (this.arg = undefined), ContinueSentinel; } }, exports; }
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
 
 
 
@@ -8420,6 +8428,67 @@ var FollowNumbers = function FollowNumbers(props) {
   // id: 表示ユーザー authUserId: ログインしているユーザー
   var userId = props.userId,
       isAuth = props.isAuth;
+
+  var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
+      follows = _useState.follows,
+      setFollows = _useState.setFollows;
+
+  var _useState2 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
+      followers = _useState2.followers,
+      setFollowers = _useState2.setFollowers; //フォロー数を取得
+
+
+  var getFollowsNumber = (0,react__WEBPACK_IMPORTED_MODULE_0__.useCallback)( /*#__PURE__*/_asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
+    var res, followsNum;
+    return _regeneratorRuntime().wrap(function _callee$(_context) {
+      while (1) {
+        switch (_context.prev = _context.next) {
+          case 0:
+            _context.next = 2;
+            return fetch("/countFollows/".concat(userId));
+
+          case 2:
+            res = _context.sent;
+
+            if (!(res.status === 200)) {
+              _context.next = 9;
+              break;
+            }
+
+            _context.next = 6;
+            return res.json();
+
+          case 6:
+            followsNum = _context.sent;
+            console.log(followsNum);
+            setFollows(followsNum);
+
+          case 9:
+          case "end":
+            return _context.stop();
+        }
+      }
+    }, _callee);
+  })));
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
+    console.log(userId);
+    getFollowsNumber();
+
+    var cleanup = function cleanup() {
+      console.log("cleanup!");
+    };
+
+    return cleanup;
+  }, []); // フォロワー数を取得
+  // const getFollowersNumber = async () => {
+  //     const res = await fetch(`/countFollowers/${userId}`);
+  //     if (res.status === 200) {
+  //         const followersNum = await res.json();
+  //         console.log(followersNum);
+  //         return followersNum;
+  //     }
+  // };
+
   return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("div", {
     className: "mt-1",
     children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsxs)("div", {
@@ -8430,7 +8499,7 @@ var FollowNumbers = function FollowNumbers(props) {
           type: "button",
           children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("span", {
             className: "fw-bold",
-            children: "100"
+            children: follows
           }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("p", {
             className: "ms-1",
             children: "\u30D5\u30A9\u30ED\u30FC"
@@ -8442,7 +8511,7 @@ var FollowNumbers = function FollowNumbers(props) {
           type: "button",
           children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("span", {
             className: "fw-bold",
-            children: "110"
+            children: followers
           }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("p", {
             className: "ms-1",
             children: "\u30D5\u30A9\u30ED\u30EF\u30FC"

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -7819,7 +7819,7 @@ var UserList = function UserList() {
 
   var getAuthUserData = /*#__PURE__*/function () {
     var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
-      var res, authUserData;
+      var res, authUser;
       return _regeneratorRuntime().wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
@@ -7845,8 +7845,8 @@ var UserList = function UserList() {
               return res.json();
 
             case 6:
-              authUserData = _context.sent;
-              return _context.abrupt("return", authUserData);
+              authUser = _context.sent;
+              return _context.abrupt("return", authUser);
 
             case 8:
             case "end":
@@ -7874,8 +7874,8 @@ var UserList = function UserList() {
 
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
     // 認証ユーザーのプロフィールとフォロー関係データを呼び出す
-    getAuthUserData().then(function (authUserData) {
-      checkAuthUserFollows(authUserData.follows, authUserData.authuser.id);
+    getAuthUserData().then(function (authUser) {
+      checkAuthUserFollows(authUser.follows, authUser.profile.id);
     });
   }, []);
 
@@ -8115,7 +8115,7 @@ var UserProfile = function UserProfile() {
 
   var getAuthUserData = /*#__PURE__*/function () {
     var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
-      var res, authUserData;
+      var res, authUser;
       return _regeneratorRuntime().wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
@@ -8133,7 +8133,7 @@ var UserProfile = function UserProfile() {
               res = _context.sent;
 
               if (!(res.status === 200)) {
-                _context.next = 9;
+                _context.next = 8;
                 break;
               }
 
@@ -8141,11 +8141,10 @@ var UserProfile = function UserProfile() {
               return res.json();
 
             case 6:
-              authUserData = _context.sent;
-              console.log(authUserData);
-              return _context.abrupt("return", authUserData);
+              authUser = _context.sent;
+              return _context.abrupt("return", authUser);
 
-            case 9:
+            case 8:
             case "end":
               return _context.stop();
           }
@@ -8159,23 +8158,23 @@ var UserProfile = function UserProfile() {
   }(); // 認証ユーザーがフォローしているユーザ一覧を配列でsetAuthUserFollowsにセット
 
 
-  var checkAuthUserFollows = function checkAuthUserFollows(authUserFollows, authUserId) {
-    var authUserFollowsList = authUserFollows.filter(function (data) {
+  var checkAuthUserFollows = function checkAuthUserFollows(authUserFollowsList, authUserId) {
+    var authUserFollows = authUserFollowsList.filter(function (data) {
       return Number(data["follow_user_id"]) === authUserId;
     }).map(function (data) {
       return Number(data["followed_user_id"]);
     });
-    setAuthUserFollows(authUserFollowsList);
-  }; // 認証ユーザーがフォローしているユーザーリストをauthUserFollowsにセットする
-
+    setAuthUserFollows(authUserFollows);
+  };
 
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
-    // 認証ユーザーのプロフィールとフォロー関係データを呼び出す
-    getAuthUserData().then(function (authUserData) {
-      setIsAuth(authUserData.authuser.id === Number(id));
-      checkAuthUserFollows(authUserData.follows, authUserData.authuser.id);
+    getAuthUserData().then(function (authUser) {
+      // 認証ユーザーか確認
+      setIsAuth(authUser.profile.id === Number(id)); // 認証ユーザーがフォローしているか確認
+
+      checkAuthUserFollows(authUser.follows, authUser.profile.id);
     });
-  }, []);
+  }, []); // 表示するユーザープロフィールをセット
 
   var getUserProfile = /*#__PURE__*/function () {
     var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2() {
@@ -8218,7 +8217,7 @@ var UserProfile = function UserProfile() {
 
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
     getUserProfile();
-  }, [authUserFollows]);
+  }, [authUserFollows]); // 認証ユーザーとそうでない場合でボタンを切り替え
 
   var profileButton = function profileButton() {
     if (isAuth) {
@@ -8436,23 +8435,23 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 var FollowNumbers = function FollowNumbers(props) {
-  // id: 表示ユーザー authUserId: ログインしているユーザー
+  // 表示したいユーザーのID
   var userId = props.userId;
 
   var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
       _useState2 = _slicedToArray(_useState, 2),
-      follows = _useState2[0],
-      setFollows = _useState2[1];
+      followsNum = _useState2[0],
+      setFollowsNum = _useState2[1];
 
   var _useState3 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
       _useState4 = _slicedToArray(_useState3, 2),
-      followers = _useState4[0],
-      setFollowers = _useState4[1]; //フォロー数を取得
+      followersNum = _useState4[0],
+      setFollowersNum = _useState4[1]; //フォロー数を取得
 
 
   var getFollowsNumber = /*#__PURE__*/function () {
     var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
-      var res, followsNum;
+      var res, follows;
       return _regeneratorRuntime().wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
@@ -8464,7 +8463,7 @@ var FollowNumbers = function FollowNumbers(props) {
               res = _context.sent;
 
               if (!(res.status === 200)) {
-                _context.next = 9;
+                _context.next = 8;
                 break;
               }
 
@@ -8472,11 +8471,10 @@ var FollowNumbers = function FollowNumbers(props) {
               return res.json();
 
             case 6:
-              followsNum = _context.sent;
-              console.log(followsNum);
-              setFollows(followsNum);
+              follows = _context.sent;
+              setFollowsNum(follows);
 
-            case 9:
+            case 8:
             case "end":
               return _context.stop();
           }
@@ -8487,16 +8485,12 @@ var FollowNumbers = function FollowNumbers(props) {
     return function getFollowsNumber() {
       return _ref.apply(this, arguments);
     };
-  }();
+  }(); // フォロワー数を取得
 
-  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
-    getFollowsNumber();
-    getFollowersNumber();
-  }, []); // フォロワー数を取得
 
   var getFollowersNumber = /*#__PURE__*/function () {
     var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2() {
-      var res, followersNum;
+      var res, followers;
       return _regeneratorRuntime().wrap(function _callee2$(_context2) {
         while (1) {
           switch (_context2.prev = _context2.next) {
@@ -8508,7 +8502,7 @@ var FollowNumbers = function FollowNumbers(props) {
               res = _context2.sent;
 
               if (!(res.status === 200)) {
-                _context2.next = 9;
+                _context2.next = 8;
                 break;
               }
 
@@ -8516,11 +8510,10 @@ var FollowNumbers = function FollowNumbers(props) {
               return res.json();
 
             case 6:
-              followersNum = _context2.sent;
-              console.log(followersNum);
-              setFollowers(followersNum);
+              followers = _context2.sent;
+              setFollowersNum(followers);
 
-            case 9:
+            case 8:
             case "end":
               return _context2.stop();
           }
@@ -8533,6 +8526,10 @@ var FollowNumbers = function FollowNumbers(props) {
     };
   }();
 
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
+    getFollowsNumber();
+    getFollowersNumber();
+  }, []);
   return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("div", {
     className: "mt-1",
     children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsxs)("div", {
@@ -8543,7 +8540,7 @@ var FollowNumbers = function FollowNumbers(props) {
           type: "button",
           children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("span", {
             className: "fw-bold",
-            children: follows
+            children: followsNum
           }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("p", {
             className: "ms-1",
             children: "\u30D5\u30A9\u30ED\u30FC"
@@ -8555,7 +8552,7 @@ var FollowNumbers = function FollowNumbers(props) {
           type: "button",
           children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("span", {
             className: "fw-bold",
-            children: followers
+            children: followersNum
           }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("p", {
             className: "ms-1",
             children: "\u30D5\u30A9\u30ED\u30EF\u30FC"

--- a/src/resources/js/components/App.jsx
+++ b/src/resources/js/components/App.jsx
@@ -1,21 +1,27 @@
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import { UserList } from "./page/UserList";
+import { UserProfile } from "./page/UserProfile";
+import { Header } from "./layout/Header";
 
 import "../../css/app.css";
-import { Header } from "./layout/Header";
-import { TweetBtn } from "./layout/TweetBtn";
 
 export const App = () => {
+    //　一覧表示するユーザデータを入れる
+    const [users, setUsers] = useState([]);
+
     return (
         <BrowserRouter>
             <Header />
             <Routes>
-                <Route path="/userList" element={<UserList />} />
+                <Route
+                    path="/userList"
+                    element={<UserList setUsers={setUsers} users={users} />}
+                />
+                <Route path={`/profile/:id`} element={<UserProfile />} />
             </Routes>
-            <TweetBtn />
         </BrowserRouter>
     );
 };

--- a/src/resources/js/components/page/UserList.jsx
+++ b/src/resources/js/components/page/UserList.jsx
@@ -96,7 +96,7 @@ export const UserList = () => {
         return (
             <li key={item.id}>
                 <div className="user__item-container">
-                    <Link to={`/users/${item.id}`}>
+                    <Link to={`/profile/${item.id}`}>
                         <div className="d-flex px-2 py-4 w-100">
                             <UserIcon
                                 iconData={{
@@ -107,8 +107,8 @@ export const UserList = () => {
                                 <div className="d-flex justify-content-between">
                                     <UserName
                                         nameData={{
-                                            name: item.screen_name,
-                                            id: item.user_name,
+                                            screen_name: item.screen_name,
+                                            user_name: item.user_name,
                                         }}
                                     />
                                     <FollowButton

--- a/src/resources/js/components/page/UserList.jsx
+++ b/src/resources/js/components/page/UserList.jsx
@@ -25,8 +25,8 @@ export const UserList = () => {
             },
         });
         if (res.status === 200) {
-            const authUserData = await res.json();
-            return authUserData;
+            const authUser = await res.json();
+            return authUser;
         }
     };
 
@@ -45,11 +45,8 @@ export const UserList = () => {
     // 認証ユーザーがフォローしているユーザーリストをauthUserFollowsにセットする
     useEffect(() => {
         // 認証ユーザーのプロフィールとフォロー関係データを呼び出す
-        getAuthUserData().then((authUserData) => {
-            checkAuthUserFollows(
-                authUserData.follows,
-                authUserData.authuser.id
-            );
+        getAuthUserData().then((authUser) => {
+            checkAuthUserFollows(authUser.follows, authUser.profile.id);
         });
     }, []);
 

--- a/src/resources/js/components/page/UserList.jsx
+++ b/src/resources/js/components/page/UserList.jsx
@@ -25,28 +25,25 @@ export const UserList = () => {
             },
         });
         if (res.status === 200) {
-            const authUser = await res.json();
-            return authUser;
+            const authUserData = await res.json();
+            return authUserData;
         }
     };
 
-    // 認証ユーザーがフォローしているユーザ一覧を配列でsetAuthUserFollowsにセット
-    const checkAuthUserFollows = (authUserFollows, authUserId) => {
-        const authUserFollowsList = authUserFollows
-            .filter((data) => {
-                return Number(data["follow_user_id"]) === authUserId;
-            })
-            .map((data) => {
-                return Number(data["followed_user_id"]);
-            });
+    // 認証ユーザーがフォローしているリストを配列でsetAuthUserFollowsにセット
+    const checkAuthUserFollows = (authUserFollows) => {
+        const authUserFollowsList = authUserFollows.map((data) =>
+            Number(data.followed_user_id)
+        );
+
         setAuthUserFollows(authUserFollowsList);
     };
 
     // 認証ユーザーがフォローしているユーザーリストをauthUserFollowsにセットする
     useEffect(() => {
         // 認証ユーザーのプロフィールとフォロー関係データを呼び出す
-        getAuthUserData().then((authUser) => {
-            checkAuthUserFollows(authUser.follows, authUser.profile.id);
+        getAuthUserData().then((authUserData) => {
+            checkAuthUserFollows(authUserData.follows);
         });
     }, []);
 
@@ -93,7 +90,7 @@ export const UserList = () => {
         return (
             <li key={item.id}>
                 <div className="user__item-container">
-                    <Link to={`/profile/${item.id}`}>
+                    <Link to={`/profile-${item.id}`}>
                         <div className="d-flex px-2 py-4 w-100">
                             <UserIcon
                                 iconData={{

--- a/src/resources/js/components/page/UserProfile.jsx
+++ b/src/resources/js/components/page/UserProfile.jsx
@@ -1,0 +1,158 @@
+import React, { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { FollowButton } from "../parts/FollowButton";
+import { FollowNumbers } from "../parts/FollowNumbers";
+import { UserIcon } from "../parts/UserIcon";
+import { UserName } from "../parts/UserName";
+
+export const UserProfile = () => {
+    const [authUserFollows, setAuthUserFollows] = useState([]);
+    const [user, setUser] = useState({});
+    const [isFollowing, setIsFollowing] = useState(false);
+    const [isAuth, setIsAuth] = useState(false);
+
+    // ユーザーIDの取得
+    const { id } = useParams();
+
+    // csrf対策のため、トークンを取得
+    const csrf_token = document.querySelector(
+        'meta[name="csrf-token"]'
+    ).content;
+    // /authuser 認証ユーザーの情報取得
+    const getAuthUserData = async () => {
+        const res = await fetch("/authuser", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-CSRF-TOKEN": csrf_token,
+            },
+        });
+        if (res.status === 200) {
+            const authUserData = await res.json();
+            console.log(authUserData);
+            return authUserData;
+        }
+    };
+
+    // 認証ユーザーがフォローしているユーザ一覧を配列でsetAuthUserFollowsにセット
+    const checkAuthUserFollows = (authUserFollows, authUserId) => {
+        const authUserFollowsList = authUserFollows
+            .filter((data) => {
+                return Number(data["follow_user_id"]) === authUserId;
+            })
+            .map((data) => {
+                return Number(data["followed_user_id"]);
+            });
+        setAuthUserFollows(authUserFollowsList);
+    };
+
+    // 認証ユーザーがフォローしているユーザーリストをauthUserFollowsにセットする
+    useEffect(() => {
+        // 認証ユーザーのプロフィールとフォロー関係データを呼び出す
+        getAuthUserData().then((authUserData) => {
+            setIsAuth(authUserData.authuser.id === Number(id));
+            checkAuthUserFollows(
+                authUserData.follows,
+                authUserData.authuser.id
+            );
+        });
+    }, []);
+
+    const getUserProfile = async () => {
+        const res = await fetch(`/user/${id}`);
+        if (res.status === 200) {
+            const userProfile = await res.json();
+            setIsFollowing(authUserFollows.includes(Number(id)));
+            setUser(userProfile);
+        }
+    };
+
+    useEffect(() => {
+        getUserProfile();
+    }, [authUserFollows]);
+
+    const profileButton = () => {
+        if (isAuth) {
+            return (
+                <button type="button" className="btn btn-outline-dark">
+                    編集
+                </button>
+            );
+        } else {
+            return (
+                <FollowButton
+                    userId={id}
+                    user={user}
+                    isFollowing={isFollowing}
+                />
+            );
+        }
+    };
+
+    return (
+        <div className="container-lg mt-5">
+            <div className="border">
+                <div onClick={() => console.log(isFollowing)}>
+                    <div className="d-flex p-1">
+                        <Link to="/userlist">
+                            <button className="btn">
+                                <svg
+                                    viewBox="0 0 16 16"
+                                    width="16"
+                                    height="16"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="#111111"
+                                    className="bi bi-arrow-left"
+                                >
+                                    <path d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z" />
+                                </svg>
+                            </button>
+                        </Link>
+                        <div className="me-3">
+                            <h2>{user.screen_name}</h2>
+                        </div>
+                    </div>
+                    <div>
+                        <img
+                            className="w-100 bg-primary"
+                            style={{ height: "160px" }}
+                            src="/images/twitter-cover-example.png"
+                            alt="プロフィール カバー画像"
+                        />
+                    </div>
+                </div>
+                <div className="p-3">
+                    <div className="position-relative">
+                        <div className="w-100 d-flex justify-content-end">
+                            {profileButton()}
+                        </div>
+                        <UserIcon
+                            userList={false}
+                            iconData={{
+                                icon: user.icon,
+                                desc: user.iconDesc,
+                            }}
+                        />
+                    </div>
+                    <div>
+                        <UserName
+                            isUserProfile={true}
+                            nameData={{
+                                screen_name: user.screen_name,
+                                user_name: user.user_name,
+                            }}
+                        />
+                        <div className="mt-1">
+                            <p>{user.profile}</p>
+                        </div>
+                    </div>
+                    <FollowNumbers userId={id} isAuth={isAuth} />
+                </div>
+            </div>
+            <div className="border">
+                <p>ツイート一覧</p>
+            </div>
+        </div>
+    );
+};

--- a/src/resources/js/components/page/UserProfile.jsx
+++ b/src/resources/js/components/page/UserProfile.jsx
@@ -19,6 +19,7 @@ export const UserProfile = () => {
     const csrf_token = document.querySelector(
         'meta[name="csrf-token"]'
     ).content;
+
     // /authuser 認証ユーザーの情報取得
     const getAuthUserData = async () => {
         const res = await fetch("/authuser", {
@@ -29,36 +30,33 @@ export const UserProfile = () => {
             },
         });
         if (res.status === 200) {
-            const authUserData = await res.json();
-            console.log(authUserData);
-            return authUserData;
+            const authUser = await res.json();
+            return authUser;
         }
     };
 
     // 認証ユーザーがフォローしているユーザ一覧を配列でsetAuthUserFollowsにセット
-    const checkAuthUserFollows = (authUserFollows, authUserId) => {
-        const authUserFollowsList = authUserFollows
+    const checkAuthUserFollows = (authUserFollowsList, authUserId) => {
+        const authUserFollows = authUserFollowsList
             .filter((data) => {
                 return Number(data["follow_user_id"]) === authUserId;
             })
             .map((data) => {
                 return Number(data["followed_user_id"]);
             });
-        setAuthUserFollows(authUserFollowsList);
+        setAuthUserFollows(authUserFollows);
     };
 
-    // 認証ユーザーがフォローしているユーザーリストをauthUserFollowsにセットする
     useEffect(() => {
-        // 認証ユーザーのプロフィールとフォロー関係データを呼び出す
-        getAuthUserData().then((authUserData) => {
-            setIsAuth(authUserData.authuser.id === Number(id));
-            checkAuthUserFollows(
-                authUserData.follows,
-                authUserData.authuser.id
-            );
+        getAuthUserData().then((authUser) => {
+            // 認証ユーザーか確認
+            setIsAuth(authUser.profile.id === Number(id));
+            // 認証ユーザーがフォローしているか確認
+            checkAuthUserFollows(authUser.follows, authUser.profile.id);
         });
     }, []);
 
+    // 表示するユーザープロフィールをセット
     const getUserProfile = async () => {
         const res = await fetch(`/user/${id}`);
         if (res.status === 200) {
@@ -72,6 +70,7 @@ export const UserProfile = () => {
         getUserProfile();
     }, [authUserFollows]);
 
+    // 認証ユーザーとそうでない場合でボタンを切り替え
     const profileButton = () => {
         if (isAuth) {
             return (
@@ -150,6 +149,8 @@ export const UserProfile = () => {
                     <FollowNumbers userId={id} />
                 </div>
             </div>
+
+            {/* ツイート一覧は余裕があれば追加予定 */}
             <div className="border">
                 <p>ツイート一覧</p>
             </div>

--- a/src/resources/js/components/page/UserProfile.jsx
+++ b/src/resources/js/components/page/UserProfile.jsx
@@ -147,7 +147,7 @@ export const UserProfile = () => {
                             <p>{user.profile}</p>
                         </div>
                     </div>
-                    <FollowNumbers userId={id} isAuth={isAuth} />
+                    <FollowNumbers userId={id} />
                 </div>
             </div>
             <div className="border">

--- a/src/resources/js/components/page/UserProfile.jsx
+++ b/src/resources/js/components/page/UserProfile.jsx
@@ -19,7 +19,6 @@ export const UserProfile = () => {
     const csrf_token = document.querySelector(
         'meta[name="csrf-token"]'
     ).content;
-
     // /authuser 認証ユーザーの情報取得
     const getAuthUserData = async () => {
         const res = await fetch("/authuser", {
@@ -30,35 +29,31 @@ export const UserProfile = () => {
             },
         });
         if (res.status === 200) {
-            const authUser = await res.json();
-            return authUser;
+            const authUserData = await res.json();
+            return authUserData;
         }
     };
 
     // 認証ユーザーがフォローしているユーザ一覧を配列でsetAuthUserFollowsにセット
-    const checkAuthUserFollows = (authUserFollowsList, authUserId) => {
-        const authUserFollows = authUserFollowsList
-            .filter((data) => {
-                return Number(data["follow_user_id"]) === authUserId;
-            })
-            .map((data) => {
-                return Number(data["followed_user_id"]);
-            });
-        setAuthUserFollows(authUserFollows);
+    const checkAuthUserFollows = (authUserFollows) => {
+        const authUserFollowsList = authUserFollows.map((data) =>
+            Number(data.followed_user_id)
+        );
+
+        setAuthUserFollows(authUserFollowsList);
     };
 
+    // 認証ユーザーがフォローしているユーザーリストをauthUserFollowsにセットする
     useEffect(() => {
-        getAuthUserData().then((authUser) => {
-            // 認証ユーザーか確認
-            setIsAuth(authUser.profile.id === Number(id));
-            // 認証ユーザーがフォローしているか確認
-            checkAuthUserFollows(authUser.follows, authUser.profile.id);
+        // 認証ユーザーのプロフィールとフォロー関係データを呼び出す
+        getAuthUserData().then((authUserData) => {
+            setIsAuth(authUserData.userId === Number(id));
+            checkAuthUserFollows(authUserData.follows);
         });
     }, []);
 
-    // 表示するユーザープロフィールをセット
     const getUserProfile = async () => {
-        const res = await fetch(`/user/${id}`);
+        const res = await fetch(`/user-${id}`);
         if (res.status === 200) {
             const userProfile = await res.json();
             setIsFollowing(authUserFollows.includes(Number(id)));
@@ -70,7 +65,6 @@ export const UserProfile = () => {
         getUserProfile();
     }, [authUserFollows]);
 
-    // 認証ユーザーとそうでない場合でボタンを切り替え
     const profileButton = () => {
         if (isAuth) {
             return (
@@ -146,11 +140,9 @@ export const UserProfile = () => {
                             <p>{user.profile}</p>
                         </div>
                     </div>
-                    <FollowNumbers userId={id} />
+                    <FollowNumbers userId={id} isAuth={isAuth} />
                 </div>
             </div>
-
-            {/* ツイート一覧は余裕があれば追加予定 */}
             <div className="border">
                 <p>ツイート一覧</p>
             </div>

--- a/src/resources/js/components/parts/FollowButton.jsx
+++ b/src/resources/js/components/parts/FollowButton.jsx
@@ -24,14 +24,14 @@ export const FollowButton = (props) => {
 
     const followUser = (e) => {
         e.preventDefault();
-        fetch(`/follow/${userId}`, options).then(() => {
+        fetch(`/follow-${userId}`, options).then(() => {
             setFollowStatus(true);
         });
     };
 
     const unfollowUser = (e) => {
         e.preventDefault();
-        fetch(`/unfollow/${userId}`, options).then(() =>
+        fetch(`/unfollow-${userId}`, options).then(() =>
             setFollowStatus(false)
         );
     };

--- a/src/resources/js/components/parts/FollowButton.jsx
+++ b/src/resources/js/components/parts/FollowButton.jsx
@@ -6,10 +6,8 @@ export const FollowButton = (props) => {
     const [followStatus, setFollowStatus] = useState(false);
 
     useEffect(() => {
-        // console.log("isFollowing");
-        // console.log(isFollowing);
         setFollowStatus(isFollowing);
-    }, [users, authUserfollows]);
+    }, [users, isFollowing]);
 
     // csrf対策のため、トークンを取得
     const csrf_token = document.querySelector(
@@ -39,18 +37,14 @@ export const FollowButton = (props) => {
     };
 
     return (
-        <>
-            <button
-                type="button"
-                className={`btn ${
-                    followStatus ? "btn-dark" : "btn-outline-dark"
-                }`}
-                onClick={
-                    followStatus ? (e) => unfollowUser(e) : (e) => followUser(e)
-                }
-            >
-                {followStatus ? "フォロー解除" : "フォロー"}
-            </button>
-        </>
+        <button
+            type="button"
+            className={`btn ${followStatus ? "btn-dark" : "btn-outline-dark"}`}
+            onClick={
+                followStatus ? (e) => unfollowUser(e) : (e) => followUser(e)
+            }
+        >
+            {followStatus ? "フォロー解除" : "フォロー"}
+        </button>
     );
 };

--- a/src/resources/js/components/parts/FollowNumbers.jsx
+++ b/src/resources/js/components/parts/FollowNumbers.jsx
@@ -1,19 +1,27 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState } from "react";
 
 export const FollowNumbers = (props) => {
-    // id: 表示ユーザー authUserId: ログインしているユーザー
+    // 表示したいユーザーのID
     const { userId } = props;
 
-    const [follows, setFollows] = useState(0);
-    const [followers, setFollowers] = useState(0);
+    const [followsNum, setFollowsNum] = useState(0);
+    const [followersNum, setFollowersNum] = useState(0);
 
     //フォロー数を取得
     const getFollowsNumber = async () => {
         const res = await fetch(`/countFollows/${userId}`);
         if (res.status === 200) {
-            const followsNum = await res.json();
-            console.log(followsNum);
-            setFollows(followsNum);
+            const follows = await res.json();
+            setFollowsNum(follows);
+        }
+    };
+
+    // フォロワー数を取得
+    const getFollowersNumber = async () => {
+        const res = await fetch(`/countFollowers/${userId}`);
+        if (res.status === 200) {
+            const followers = await res.json();
+            setFollowersNum(followers);
         }
     };
 
@@ -22,28 +30,18 @@ export const FollowNumbers = (props) => {
         getFollowersNumber();
     }, []);
 
-    // フォロワー数を取得
-    const getFollowersNumber = async () => {
-        const res = await fetch(`/countFollowers/${userId}`);
-        if (res.status === 200) {
-            const followersNum = await res.json();
-            console.log(followersNum);
-            setFollowers(followersNum);
-        }
-    };
-
     return (
         <div className="mt-1">
             <div className="d-flex">
                 <div>
                     <button className="d-flex" type="button">
-                        <span className="fw-bold">{follows}</span>
+                        <span className="fw-bold">{followsNum}</span>
                         <p className="ms-1">フォロー</p>
                     </button>
                 </div>
                 <div>
                     <button className="d-flex ms-3" type="button">
-                        <span className="fw-bold">{followers}</span>
+                        <span className="fw-bold">{followersNum}</span>
                         <p className="ms-1">フォロワー</p>
                     </button>
                 </div>

--- a/src/resources/js/components/parts/FollowNumbers.jsx
+++ b/src/resources/js/components/parts/FollowNumbers.jsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState, useCallback } from "react";
+
+export const FollowNumbers = (props) => {
+    // id: 表示ユーザー authUserId: ログインしているユーザー
+    const { userId, isAuth } = props;
+
+    return (
+        <div className="mt-1">
+            <div className="d-flex">
+                <div>
+                    <button className="d-flex" type="button">
+                        <span className="fw-bold">100</span>
+                        <p className="ms-1">フォロー</p>
+                    </button>
+                </div>
+                <div>
+                    <button className="d-flex ms-3" type="button">
+                        <span className="fw-bold">110</span>
+                        <p className="ms-1">フォロワー</p>
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/resources/js/components/parts/FollowNumbers.jsx
+++ b/src/resources/js/components/parts/FollowNumbers.jsx
@@ -4,18 +4,54 @@ export const FollowNumbers = (props) => {
     // id: 表示ユーザー authUserId: ログインしているユーザー
     const { userId, isAuth } = props;
 
+    const { follows, setFollows } = useState(0);
+    const { followers, setFollowers } = useState(0);
+
+    //フォロー数を取得
+    const getFollowsNumber = useCallback(async () => {
+        const res = await fetch(`/countFollows/${userId}`);
+        if (res.status === 200) {
+            const followsNum = await res.json();
+            console.log(followsNum);
+            setFollows(followsNum);
+        }
+    });
+
+    useEffect(() => {
+        console.log(userId);
+
+        getFollowsNumber();
+
+        const cleanup = () => {
+            console.log("cleanup!");
+        };
+        return cleanup;
+    }, []);
+
+    // フォロワー数を取得
+    // const getFollowersNumber = async () => {
+    //     const res = await fetch(`/countFollowers/${userId}`);
+    //     if (res.status === 200) {
+    //         const followersNum = await res.json();
+    //         console.log(followersNum);
+    //         return followersNum;
+    //     }
+    // };
+
+
+
     return (
         <div className="mt-1">
             <div className="d-flex">
                 <div>
                     <button className="d-flex" type="button">
-                        <span className="fw-bold">100</span>
+                        <span className="fw-bold">{follows}</span>
                         <p className="ms-1">フォロー</p>
                     </button>
                 </div>
                 <div>
                     <button className="d-flex ms-3" type="button">
-                        <span className="fw-bold">110</span>
+                        <span className="fw-bold">{followers}</span>
                         <p className="ms-1">フォロワー</p>
                     </button>
                 </div>

--- a/src/resources/js/components/parts/FollowNumbers.jsx
+++ b/src/resources/js/components/parts/FollowNumbers.jsx
@@ -9,7 +9,7 @@ export const FollowNumbers = (props) => {
 
     //フォロー数を取得
     const getFollowsNumber = async () => {
-        const res = await fetch(`/countFollows-${userId}`);
+        const res = await fetch(`/count-follows/${userId}`);
         if (res.status === 200) {
             const follows = await res.json();
             setFollowsNum(follows);
@@ -18,7 +18,7 @@ export const FollowNumbers = (props) => {
 
     // フォロワー数を取得
     const getFollowersNumber = async () => {
-        const res = await fetch(`/countFollowers-${userId}`);
+        const res = await fetch(`/count-followers/${userId}`);
         if (res.status === 200) {
             const followers = await res.json();
             setFollowersNum(followers);

--- a/src/resources/js/components/parts/FollowNumbers.jsx
+++ b/src/resources/js/components/parts/FollowNumbers.jsx
@@ -2,43 +2,35 @@ import React, { useEffect, useState, useCallback } from "react";
 
 export const FollowNumbers = (props) => {
     // id: 表示ユーザー authUserId: ログインしているユーザー
-    const { userId, isAuth } = props;
+    const { userId } = props;
 
-    const { follows, setFollows } = useState(0);
-    const { followers, setFollowers } = useState(0);
+    const [follows, setFollows] = useState(0);
+    const [followers, setFollowers] = useState(0);
 
     //フォロー数を取得
-    const getFollowsNumber = useCallback(async () => {
+    const getFollowsNumber = async () => {
         const res = await fetch(`/countFollows/${userId}`);
         if (res.status === 200) {
             const followsNum = await res.json();
             console.log(followsNum);
             setFollows(followsNum);
         }
-    });
+    };
 
     useEffect(() => {
-        console.log(userId);
-
         getFollowsNumber();
-
-        const cleanup = () => {
-            console.log("cleanup!");
-        };
-        return cleanup;
+        getFollowersNumber();
     }, []);
 
     // フォロワー数を取得
-    // const getFollowersNumber = async () => {
-    //     const res = await fetch(`/countFollowers/${userId}`);
-    //     if (res.status === 200) {
-    //         const followersNum = await res.json();
-    //         console.log(followersNum);
-    //         return followersNum;
-    //     }
-    // };
-
-
+    const getFollowersNumber = async () => {
+        const res = await fetch(`/countFollowers/${userId}`);
+        if (res.status === 200) {
+            const followersNum = await res.json();
+            console.log(followersNum);
+            setFollowers(followersNum);
+        }
+    };
 
     return (
         <div className="mt-1">

--- a/src/resources/js/components/parts/FollowNumbers.jsx
+++ b/src/resources/js/components/parts/FollowNumbers.jsx
@@ -9,7 +9,7 @@ export const FollowNumbers = (props) => {
 
     //フォロー数を取得
     const getFollowsNumber = async () => {
-        const res = await fetch(`/countFollows/${userId}`);
+        const res = await fetch(`/countFollows-${userId}`);
         if (res.status === 200) {
             const follows = await res.json();
             setFollowsNum(follows);
@@ -18,7 +18,7 @@ export const FollowNumbers = (props) => {
 
     // フォロワー数を取得
     const getFollowersNumber = async () => {
-        const res = await fetch(`/countFollowers/${userId}`);
+        const res = await fetch(`/countFollowers-${userId}`);
         if (res.status === 200) {
             const followers = await res.json();
             setFollowersNum(followers);

--- a/src/resources/js/components/parts/UserName.jsx
+++ b/src/resources/js/components/parts/UserName.jsx
@@ -1,12 +1,13 @@
 import React from "react";
 
 export const UserName = (props) => {
+    const { isUserDetail, nameData } = props;
     return (
-        <div className={`${props.isUserDetail ? "mt-2" : ""}`}>
-            <p className={`lh-sm fw-bold ${props.isUserDetail ? "fs-4" : ""}`}>
-                {props.nameData.name}
+        <div className={`${isUserDetail ? "mt-2" : ""}`}>
+            <p className={`lh-sm fw-bold ${isUserDetail ? "fs-4" : ""}`}>
+                {nameData.screen_name}
             </p>
-            <span className="opacity-50">＠{props.nameData.id}</span>
+            <span className="opacity-50">＠{nameData.user_name}</span>
         </div>
     );
 };

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -16,13 +16,13 @@ Auth::routes();
 
 Route::middleware('auth')->group(function () {
     Route::get('/users', [UserController::class, 'index']);
-    Route::get('/user/{userId}', [UserController::class, 'show']);
+    Route::get('/user-{userId}', [UserController::class, 'show']);
 
-    Route::get('/countFollows/{userId}', [UserController::class, 'countFollows']);
-    Route::get('/countFollowers/{userId}', [UserController::class, 'countFollowers']);
+    Route::get('/countFollows-{userId}', [UserController::class, 'countFollows']);
+    Route::get('/countFollowers-{userId}', [UserController::class, 'countFollowers']);
 
-    Route::post('/follow/{userId}', [UserController::class, 'follow']);
-    Route::post('/unfollow/{userId}', [UserController::class, 'unfollow']);
+    Route::post('/follow-{userId}', [UserController::class, 'follow']);
+    Route::post('/unfollow-{userId}', [UserController::class, 'unfollow']);
     Route::post('/authuser', [UserController::class, 'getAuthuserInfo']);
 });
 

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -16,7 +16,7 @@ Auth::routes();
 
 Route::middleware('auth')->group(function () {
     Route::get('/users', [UserController::class, 'index']);
-    Route::get('/users/{userId}', [UserController::class, 'show']);
+    Route::get('/user/{userId}', [UserController::class, 'show']);
 
     Route::post('/follow/{userId}', [UserController::class, 'follow']);
     Route::post('/unfollow/{userId}', [UserController::class, 'unfollow']);

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -17,6 +17,9 @@ Auth::routes();
 Route::middleware('auth')->group(function () {
     Route::get('/users', [UserController::class, 'index']);
     Route::get('/user/{userId}', [UserController::class, 'show']);
+    // フォロー数カウント
+    Route::get('/countFollows/{userId}', [UserController::class, 'countFollows']);
+    Route::get('/countFollowers/{userId}', [UserController::class, 'countFollowers']);
 
     Route::post('/follow/{userId}', [UserController::class, 'follow']);
     Route::post('/unfollow/{userId}', [UserController::class, 'unfollow']);

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -17,7 +17,7 @@ Auth::routes();
 Route::middleware('auth')->group(function () {
     Route::get('/users', [UserController::class, 'index']);
     Route::get('/user/{userId}', [UserController::class, 'show']);
-    // フォロー数カウント
+
     Route::get('/countFollows/{userId}', [UserController::class, 'countFollows']);
     Route::get('/countFollowers/{userId}', [UserController::class, 'countFollowers']);
 

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -18,8 +18,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/users', [UserController::class, 'index']);
     Route::get('/user-{userId}', [UserController::class, 'show']);
 
-    Route::get('/countFollows-{userId}', [UserController::class, 'countFollows']);
-    Route::get('/countFollowers-{userId}', [UserController::class, 'countFollowers']);
+    Route::get('/count-follows/{userId}', [UserController::class, 'countFollows']);
+    Route::get('/count-followers/{userId}', [UserController::class, 'countFollowers']);
 
     Route::post('/follow-{userId}', [UserController::class, 'follow']);
     Route::post('/unfollow-{userId}', [UserController::class, 'unfollow']);


### PR DESCRIPTION
## 概要
ユーザープロフィールの作成

## 章
４章
## 改修内容
- ユーザーごとにプロフィールページを作成
- 認証ユーザーと他ユーザーで表示を変える(認証だったら編集ボタン/他フォローボタン)
- フォロー、フォロワー数を取得して表示

### ユーザー一覧
![image](https://user-images.githubusercontent.com/49902457/175469458-af0f2681-5b68-4cdc-981b-5f36d142b9b3.png)
### ユーザープロフィール
![image](https://user-images.githubusercontent.com/49902457/175469419-8a4f32ad-e453-4a56-a5d3-f299eb4ca55c.png)

## 質問
- 今フォロー数フォロワー数のカウント処理をそれぞれ１つのメソッドに分けてControllerに書いていますが、一度にまとめてJsonなどの形式で受け取る方が呼び出し回数が減るので良いのかなと感じました。皆さんはどちらが良いと思いますか？？

## 特に見てほしいところ
- 全体的に、もっと共通化できる・短く書けるよ・こう書いた方がわかりやすいよなどのアドバイスいただきたいです。