### PR TITLE
ツイート一覧と詳細を取得してブラウザに表示

### DIFF
--- a/src/app/Consts/Paginate.php
+++ b/src/app/Consts/Paginate.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Consts;
+
+
+class Paginate
+{
+    public const NUM_TWEET_PER_PAGE = 10;
+}

--- a/src/app/Http/Controllers/TweetController.php
+++ b/src/app/Http/Controllers/TweetController.php
@@ -2,8 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use App\Consts\Paginate;
 use App\Http\Controllers\Controller;
-use App\Models\Follows;
+use App\Models\Follow;
 use App\Models\Tweet;
 use App\Models\User;
 
@@ -11,22 +12,23 @@ use App\Models\User;
 
 class TweetController extends Controller
 {
+
     /**
      * ユーザーのツイート一覧取得
      *
      * @param  int  $userId
      * @return array<object, int>
      */
-    public function index(Follows $follows, Tweet $tweet)
+    public function index(Follow $follow, Tweet $tweet)
     {
-
         $users = User::all();
 
-        $user = auth()->user();
-        $followIds = $follows->getFollowIds($user->id);
+        $userId = auth()->id();
+        $followIds = $follow->getFollowIds($userId);
 
-        $followIds[] = $user->id;
-        $tweets = $tweet->whereIn('user_id', $followIds)->orderBy('created_at', 'desc')->paginate(10);
+        $followIds[] = $userId;
+
+        $tweets = $tweet->whereIn('user_id', $followIds)->orderBy('created_at', 'desc')->paginate(Paginate::NUM_TWEET_PER_PAGE);
 
         return [
             "users" => $users,

--- a/src/app/Http/Controllers/TweetController.php
+++ b/src/app/Http/Controllers/TweetController.php
@@ -39,7 +39,8 @@ class TweetController extends Controller
     public function show(int $userId)
     {
         $tweet = Tweet::where('id', $userId)->get();
-        return $tweet;
+        // dd($tweet[0]);
+        return $tweet[0];
     }
 
     /**

--- a/src/app/Http/Controllers/TweetController.php
+++ b/src/app/Http/Controllers/TweetController.php
@@ -3,8 +3,9 @@
 namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
-use App\Models\Tweet;
 use App\Models\Follows;
+use App\Models\Tweet;
+use App\Models\User;
 
 // use Illuminate\Http\Request;
 
@@ -18,14 +19,17 @@ class TweetController extends Controller
      */
     public function index(Follows $follows, Tweet $tweet)
     {
+
+        $users = User::all();
+
         $user = auth()->user();
         $followIds = $follows->getFollowIds($user->id);
 
-        $follow_ids[] = $user->id;
-        $tweets = $tweet->whereIn('user_id', $followIds)->paginate(10);
+        $followIds[] = $user->id;
+        $tweets = $tweet->whereIn('user_id', $followIds)->orderBy('created_at', 'desc')->paginate(10);
 
         return [
-            "user" => $user->id,
+            "users" => $users,
             "tweets" => $tweets
         ];
     }
@@ -39,7 +43,6 @@ class TweetController extends Controller
     public function show(int $userId)
     {
         $tweet = Tweet::where('id', $userId)->get();
-        // dd($tweet[0]);
         return $tweet[0];
     }
 

--- a/src/app/Http/Controllers/TweetController.php
+++ b/src/app/Http/Controllers/TweetController.php
@@ -8,15 +8,14 @@ use App\Models\Follow;
 use App\Models\Tweet;
 use App\Models\User;
 
-// use Illuminate\Http\Request;
-
 class TweetController extends Controller
 {
 
     /**
      * ユーザーのツイート一覧取得
      *
-     * @param  int  $userId
+     * @param Follow $follow
+     * @param Tweet $tweet
      * @return array<object, int>
      */
     public function index(Follow $follow, Tweet $tweet)

--- a/src/app/Http/Controllers/TweetController.php
+++ b/src/app/Http/Controllers/TweetController.php
@@ -38,7 +38,7 @@ class TweetController extends Controller
      */
     public function show(int $userId)
     {
-        $tweet = Tweet::find($userId);
+        $tweet = Tweet::where('id', $userId)->get();
         return $tweet;
     }
 

--- a/src/app/Http/Controllers/TweetController.php
+++ b/src/app/Http/Controllers/TweetController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Models\Tweet;
+use App\Models\Follows;
+
+// use Illuminate\Http\Request;
+
+class TweetController extends Controller
+{
+    /**
+     * ユーザーのツイート一覧取得
+     *
+     * @param  int  $userId
+     * @return array<object, int>
+     */
+    public function index(Follows $follows, Tweet $tweet)
+    {
+        $user = auth()->user();
+        $followIds = $follows->getFollowIds($user->id);
+
+        $follow_ids[] = $user->id;
+        $tweets = $tweet->whereIn('user_id', $followIds)->paginate(10);
+
+        return [
+            "user" => $user->id,
+            "tweets" => $tweets
+        ];
+    }
+
+    /**
+     *  ユーザーのツイートID指定して取得
+     *
+     * @param  int  $userId
+     * @return object
+     */
+    public function show(int $userId)
+    {
+        $tweet = Tweet::find($userId);
+        return $tweet;
+    }
+
+    /**
+     * ツイート投稿
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -6,7 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Models\Follow;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 
 class UserController extends Controller
 {

--- a/src/app/Http/Controllers/UserController.php
+++ b/src/app/Http/Controllers/UserController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
-use App\Models\Follows;
+use App\Models\Follow;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -17,7 +17,7 @@ class UserController extends Controller
      */
     public function index(User $user)
     {
-        $users = $user->getAllUsers(auth()->user()->id);
+        $users = $user->getAllUsers(auth()->id());
 
         $numUsers = User::get()->count();
         return [
@@ -45,10 +45,10 @@ class UserController extends Controller
      */
     public function getAuthUserInfo()
     {
-        $user = auth()->user();
-        $follows = Follows::where('follow_user_id', $user->id)->get('followed_user_id');
+        $userId = auth()->id();
+        $follows = Follow::where('follow_user_id', $userId)->get('followed_user_id');
         return [
-            "userId" => $user->id,
+            "userId" => $userId,
             "follows" => $follows
         ];
     }
@@ -61,7 +61,7 @@ class UserController extends Controller
      */
     public function countFollows(int $userId)
     {
-        return Follows::where('follow_user_id', $userId)->count();
+        return Follow::where('follow_user_id', $userId)->count();
     }
 
     /**
@@ -72,7 +72,7 @@ class UserController extends Controller
      */
     public function countFollowers(int $userId)
     {
-        return Follows::where('followed_user_id', $userId)->count();
+        return Follow::where('followed_user_id', $userId)->count();
     }
 
     /**

--- a/src/app/Models/Follow.php
+++ b/src/app/Models/Follow.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-class Follows extends Authenticatable
+class Follow extends Authenticatable
 {
 
     use Notifiable, HasFactory;
@@ -15,7 +15,7 @@ class Follows extends Authenticatable
     public $timestamps = false;
 
     /**
-     *  フォローしてるIDリストを取得
+     *  フォローしてるIDリストを取得　
      *
      * @param  int  $userId
      * @return object

--- a/src/app/Models/Follows.php
+++ b/src/app/Models/Follows.php
@@ -13,4 +13,15 @@ class Follows extends Authenticatable
 
     protected $fillable = ['follow_user_id', 'followed_user_id'];
     public $timestamps = false;
+
+    /**
+     *  フォローしてるIDリストを取得
+     *
+     * @param  int  $userId
+     * @return object
+     */
+    public function getFollowIds(int $user_id)
+    {
+        return $this->where('follow_user_id', $user_id)->get('followed_user_id')->pluck('followed_user_id')->toArray();
+    }
 }

--- a/src/app/Models/Tweet.php
+++ b/src/app/Models/Tweet.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+use Laravel\Sanctum\HasApiTokens;
+
+class Tweet extends Authenticatable
+{
+
+    use HasApiTokens, HasFactory, Notifiable;
+
+    protected $guarded = [
+        'id', 'user_id', 'created_at', 'updated_at'
+    ];
+}

--- a/src/app/Models/Tweet.php
+++ b/src/app/Models/Tweet.php
@@ -11,8 +11,4 @@ class Tweet extends Authenticatable
 {
 
     use HasApiTokens, HasFactory, Notifiable;
-
-    protected $guarded = [
-        'user_id'
-    ];
 }

--- a/src/app/Models/Tweet.php
+++ b/src/app/Models/Tweet.php
@@ -13,6 +13,6 @@ class Tweet extends Authenticatable
     use HasApiTokens, HasFactory, Notifiable;
 
     protected $guarded = [
-        'user_id', 'created_at'
+        'user_id'
     ];
 }

--- a/src/app/Models/Tweet.php
+++ b/src/app/Models/Tweet.php
@@ -13,6 +13,6 @@ class Tweet extends Authenticatable
     use HasApiTokens, HasFactory, Notifiable;
 
     protected $guarded = [
-        'id', 'user_id', 'created_at', 'updated_at'
+        'user_id', 'created_at'
     ];
 }

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -7571,13 +7571,14 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ });
 /* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 /* harmony import */ var react_dom__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! react-dom */ "./node_modules/react-dom/index.js");
-/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
-/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router/index.js");
-/* harmony import */ var _page_UserList__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./page/UserList */ "./resources/js/components/page/UserList.jsx");
-/* harmony import */ var _page_UserProfile__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./page/UserProfile */ "./resources/js/components/page/UserProfile.jsx");
-/* harmony import */ var _layout_Header__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./layout/Header */ "./resources/js/components/layout/Header.jsx");
-/* harmony import */ var _css_app_css__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ../../css/app.css */ "./resources/css/app.css");
-/* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
+/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
+/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router/index.js");
+/* harmony import */ var _layout_Header__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./layout/Header */ "./resources/js/components/layout/Header.jsx");
+/* harmony import */ var _page_UserList__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./page/UserList */ "./resources/js/components/page/UserList.jsx");
+/* harmony import */ var _page_TweetList__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./page/TweetList */ "./resources/js/components/page/TweetList.jsx");
+/* harmony import */ var _page_UserProfile__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ./page/UserProfile */ "./resources/js/components/page/UserProfile.jsx");
+/* harmony import */ var _css_app_css__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ../../css/app.css */ "./resources/css/app.css");
+/* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
@@ -7599,6 +7600,7 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 
+
 var App = function App() {
   //　一覧表示するユーザデータを入れる
   var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)([]),
@@ -7606,24 +7608,27 @@ var App = function App() {
       users = _useState2[0],
       setUsers = _useState2[1];
 
-  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_7__.BrowserRouter, {
-    children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(_layout_Header__WEBPACK_IMPORTED_MODULE_4__.Header, {}), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_8__.Routes, {
-      children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_8__.Route, {
+  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_8__.BrowserRouter, {
+    children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(_layout_Header__WEBPACK_IMPORTED_MODULE_2__.Header, {}), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_9__.Routes, {
+      children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_9__.Route, {
+        path: "/",
+        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(_page_TweetList__WEBPACK_IMPORTED_MODULE_4__.TweetList, {})
+      }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_9__.Route, {
         path: "/userList",
-        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(_page_UserList__WEBPACK_IMPORTED_MODULE_2__.UserList, {
+        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(_page_UserList__WEBPACK_IMPORTED_MODULE_3__.UserList, {
           setUsers: setUsers,
           users: users
         })
-      }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_8__.Route, {
-        path: "/profile/:id",
-        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(_page_UserProfile__WEBPACK_IMPORTED_MODULE_3__.UserProfile, {})
+      }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_9__.Route, {
+        path: "/profile-:id",
+        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(_page_UserProfile__WEBPACK_IMPORTED_MODULE_5__.UserProfile, {})
       })]
     })]
   });
 };
 
 if (document.getElementById("example")) {
-  react_dom__WEBPACK_IMPORTED_MODULE_1__.render( /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_6__.jsx)(App, {}), document.getElementById("example"));
+  react_dom__WEBPACK_IMPORTED_MODULE_1__.render( /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(App, {}), document.getElementById("example"));
 }
 
 /***/ }),
@@ -7746,6 +7751,245 @@ var Header = function Header() {
         })
       })]
     })
+  });
+};
+
+/***/ }),
+
+/***/ "./resources/js/components/page/TweetList.jsx":
+/*!****************************************************!*\
+  !*** ./resources/js/components/page/TweetList.jsx ***!
+  \****************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "TweetList": () => (/* binding */ TweetList)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "./node_modules/react/index.js");
+/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
+/* harmony import */ var _parts_UserIcon__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../parts/UserIcon */ "./resources/js/components/parts/UserIcon.jsx");
+/* harmony import */ var _parts_UserName__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../parts/UserName */ "./resources/js/components/parts/UserName.jsx");
+/* harmony import */ var _parts_Pagenation__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ../parts/Pagenation */ "./resources/js/components/parts/Pagenation.jsx");
+/* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+
+function _regeneratorRuntime() { "use strict"; /*! regenerator-runtime -- Copyright (c) 2014-present, Facebook, Inc. -- license (MIT): https://github.com/facebook/regenerator/blob/main/LICENSE */ _regeneratorRuntime = function _regeneratorRuntime() { return exports; }; var exports = {}, Op = Object.prototype, hasOwn = Op.hasOwnProperty, $Symbol = "function" == typeof Symbol ? Symbol : {}, iteratorSymbol = $Symbol.iterator || "@@iterator", asyncIteratorSymbol = $Symbol.asyncIterator || "@@asyncIterator", toStringTagSymbol = $Symbol.toStringTag || "@@toStringTag"; function define(obj, key, value) { return Object.defineProperty(obj, key, { value: value, enumerable: !0, configurable: !0, writable: !0 }), obj[key]; } try { define({}, ""); } catch (err) { define = function define(obj, key, value) { return obj[key] = value; }; } function wrap(innerFn, outerFn, self, tryLocsList) { var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator, generator = Object.create(protoGenerator.prototype), context = new Context(tryLocsList || []); return generator._invoke = function (innerFn, self, context) { var state = "suspendedStart"; return function (method, arg) { if ("executing" === state) throw new Error("Generator is already running"); if ("completed" === state) { if ("throw" === method) throw arg; return doneResult(); } for (context.method = method, context.arg = arg;;) { var delegate = context.delegate; if (delegate) { var delegateResult = maybeInvokeDelegate(delegate, context); if (delegateResult) { if (delegateResult === ContinueSentinel) continue; return delegateResult; } } if ("next" === context.method) context.sent = context._sent = context.arg;else if ("throw" === context.method) { if ("suspendedStart" === state) throw state = "completed", context.arg; context.dispatchException(context.arg); } else "return" === context.method && context.abrupt("return", context.arg); state = "executing"; var record = tryCatch(innerFn, self, context); if ("normal" === record.type) { if (state = context.done ? "completed" : "suspendedYield", record.arg === ContinueSentinel) continue; return { value: record.arg, done: context.done }; } "throw" === record.type && (state = "completed", context.method = "throw", context.arg = record.arg); } }; }(innerFn, self, context), generator; } function tryCatch(fn, obj, arg) { try { return { type: "normal", arg: fn.call(obj, arg) }; } catch (err) { return { type: "throw", arg: err }; } } exports.wrap = wrap; var ContinueSentinel = {}; function Generator() {} function GeneratorFunction() {} function GeneratorFunctionPrototype() {} var IteratorPrototype = {}; define(IteratorPrototype, iteratorSymbol, function () { return this; }); var getProto = Object.getPrototypeOf, NativeIteratorPrototype = getProto && getProto(getProto(values([]))); NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol) && (IteratorPrototype = NativeIteratorPrototype); var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype); function defineIteratorMethods(prototype) { ["next", "throw", "return"].forEach(function (method) { define(prototype, method, function (arg) { return this._invoke(method, arg); }); }); } function AsyncIterator(generator, PromiseImpl) { function invoke(method, arg, resolve, reject) { var record = tryCatch(generator[method], generator, arg); if ("throw" !== record.type) { var result = record.arg, value = result.value; return value && "object" == _typeof(value) && hasOwn.call(value, "__await") ? PromiseImpl.resolve(value.__await).then(function (value) { invoke("next", value, resolve, reject); }, function (err) { invoke("throw", err, resolve, reject); }) : PromiseImpl.resolve(value).then(function (unwrapped) { result.value = unwrapped, resolve(result); }, function (error) { return invoke("throw", error, resolve, reject); }); } reject(record.arg); } var previousPromise; this._invoke = function (method, arg) { function callInvokeWithMethodAndArg() { return new PromiseImpl(function (resolve, reject) { invoke(method, arg, resolve, reject); }); } return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg(); }; } function maybeInvokeDelegate(delegate, context) { var method = delegate.iterator[context.method]; if (undefined === method) { if (context.delegate = null, "throw" === context.method) { if (delegate.iterator["return"] && (context.method = "return", context.arg = undefined, maybeInvokeDelegate(delegate, context), "throw" === context.method)) return ContinueSentinel; context.method = "throw", context.arg = new TypeError("The iterator does not provide a 'throw' method"); } return ContinueSentinel; } var record = tryCatch(method, delegate.iterator, context.arg); if ("throw" === record.type) return context.method = "throw", context.arg = record.arg, context.delegate = null, ContinueSentinel; var info = record.arg; return info ? info.done ? (context[delegate.resultName] = info.value, context.next = delegate.nextLoc, "return" !== context.method && (context.method = "next", context.arg = undefined), context.delegate = null, ContinueSentinel) : info : (context.method = "throw", context.arg = new TypeError("iterator result is not an object"), context.delegate = null, ContinueSentinel); } function pushTryEntry(locs) { var entry = { tryLoc: locs[0] }; 1 in locs && (entry.catchLoc = locs[1]), 2 in locs && (entry.finallyLoc = locs[2], entry.afterLoc = locs[3]), this.tryEntries.push(entry); } function resetTryEntry(entry) { var record = entry.completion || {}; record.type = "normal", delete record.arg, entry.completion = record; } function Context(tryLocsList) { this.tryEntries = [{ tryLoc: "root" }], tryLocsList.forEach(pushTryEntry, this), this.reset(!0); } function values(iterable) { if (iterable) { var iteratorMethod = iterable[iteratorSymbol]; if (iteratorMethod) return iteratorMethod.call(iterable); if ("function" == typeof iterable.next) return iterable; if (!isNaN(iterable.length)) { var i = -1, next = function next() { for (; ++i < iterable.length;) { if (hasOwn.call(iterable, i)) return next.value = iterable[i], next.done = !1, next; } return next.value = undefined, next.done = !0, next; }; return next.next = next; } } return { next: doneResult }; } function doneResult() { return { value: undefined, done: !0 }; } return GeneratorFunction.prototype = GeneratorFunctionPrototype, define(Gp, "constructor", GeneratorFunctionPrototype), define(GeneratorFunctionPrototype, "constructor", GeneratorFunction), GeneratorFunction.displayName = define(GeneratorFunctionPrototype, toStringTagSymbol, "GeneratorFunction"), exports.isGeneratorFunction = function (genFun) { var ctor = "function" == typeof genFun && genFun.constructor; return !!ctor && (ctor === GeneratorFunction || "GeneratorFunction" === (ctor.displayName || ctor.name)); }, exports.mark = function (genFun) { return Object.setPrototypeOf ? Object.setPrototypeOf(genFun, GeneratorFunctionPrototype) : (genFun.__proto__ = GeneratorFunctionPrototype, define(genFun, toStringTagSymbol, "GeneratorFunction")), genFun.prototype = Object.create(Gp), genFun; }, exports.awrap = function (arg) { return { __await: arg }; }, defineIteratorMethods(AsyncIterator.prototype), define(AsyncIterator.prototype, asyncIteratorSymbol, function () { return this; }), exports.AsyncIterator = AsyncIterator, exports.async = function (innerFn, outerFn, self, tryLocsList, PromiseImpl) { void 0 === PromiseImpl && (PromiseImpl = Promise); var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList), PromiseImpl); return exports.isGeneratorFunction(outerFn) ? iter : iter.next().then(function (result) { return result.done ? result.value : iter.next(); }); }, defineIteratorMethods(Gp), define(Gp, toStringTagSymbol, "Generator"), define(Gp, iteratorSymbol, function () { return this; }), define(Gp, "toString", function () { return "[object Generator]"; }), exports.keys = function (object) { var keys = []; for (var key in object) { keys.push(key); } return keys.reverse(), function next() { for (; keys.length;) { var key = keys.pop(); if (key in object) return next.value = key, next.done = !1, next; } return next.done = !0, next; }; }, exports.values = values, Context.prototype = { constructor: Context, reset: function reset(skipTempReset) { if (this.prev = 0, this.next = 0, this.sent = this._sent = undefined, this.done = !1, this.delegate = null, this.method = "next", this.arg = undefined, this.tryEntries.forEach(resetTryEntry), !skipTempReset) for (var name in this) { "t" === name.charAt(0) && hasOwn.call(this, name) && !isNaN(+name.slice(1)) && (this[name] = undefined); } }, stop: function stop() { this.done = !0; var rootRecord = this.tryEntries[0].completion; if ("throw" === rootRecord.type) throw rootRecord.arg; return this.rval; }, dispatchException: function dispatchException(exception) { if (this.done) throw exception; var context = this; function handle(loc, caught) { return record.type = "throw", record.arg = exception, context.next = loc, caught && (context.method = "next", context.arg = undefined), !!caught; } for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i], record = entry.completion; if ("root" === entry.tryLoc) return handle("end"); if (entry.tryLoc <= this.prev) { var hasCatch = hasOwn.call(entry, "catchLoc"), hasFinally = hasOwn.call(entry, "finallyLoc"); if (hasCatch && hasFinally) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } else if (hasCatch) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); } else { if (!hasFinally) throw new Error("try statement without catch or finally"); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } } } }, abrupt: function abrupt(type, arg) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc <= this.prev && hasOwn.call(entry, "finallyLoc") && this.prev < entry.finallyLoc) { var finallyEntry = entry; break; } } finallyEntry && ("break" === type || "continue" === type) && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc && (finallyEntry = null); var record = finallyEntry ? finallyEntry.completion : {}; return record.type = type, record.arg = arg, finallyEntry ? (this.method = "next", this.next = finallyEntry.finallyLoc, ContinueSentinel) : this.complete(record); }, complete: function complete(record, afterLoc) { if ("throw" === record.type) throw record.arg; return "break" === record.type || "continue" === record.type ? this.next = record.arg : "return" === record.type ? (this.rval = this.arg = record.arg, this.method = "return", this.next = "end") : "normal" === record.type && afterLoc && (this.next = afterLoc), ContinueSentinel; }, finish: function finish(finallyLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.finallyLoc === finallyLoc) return this.complete(entry.completion, entry.afterLoc), resetTryEntry(entry), ContinueSentinel; } }, "catch": function _catch(tryLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc === tryLoc) { var record = entry.completion; if ("throw" === record.type) { var thrown = record.arg; resetTryEntry(entry); } return thrown; } } throw new Error("illegal catch attempt"); }, delegateYield: function delegateYield(iterable, resultName, nextLoc) { return this.delegate = { iterator: values(iterable), resultName: resultName, nextLoc: nextLoc }, "next" === this.method && (this.arg = undefined), ContinueSentinel; } }, exports; }
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+
+
+
+
+
+
+
+var TweetList = function TweetList() {
+  var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)([]),
+      _useState2 = _slicedToArray(_useState, 2),
+      users = _useState2[0],
+      setUsers = _useState2[1];
+
+  var _useState3 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)([]),
+      _useState4 = _slicedToArray(_useState3, 2),
+      tweets = _useState4[0],
+      setTweets = _useState4[1];
+
+  var _useState5 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
+      _useState6 = _slicedToArray(_useState5, 2),
+      numUsers = _useState6[0],
+      setNumUsers = _useState6[1];
+
+  var getUsers = /*#__PURE__*/function () {
+    var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
+      var res, firstPage;
+      return _regeneratorRuntime().wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              _context.next = 2;
+              return fetch("/users");
+
+            case 2:
+              res = _context.sent;
+
+              if (!(res.status === 200)) {
+                _context.next = 8;
+                break;
+              }
+
+              _context.next = 6;
+              return res.json();
+
+            case 6:
+              firstPage = _context.sent;
+              setUsers(firstPage.users.data);
+
+            case 8:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee);
+    }));
+
+    return function getUsers() {
+      return _ref.apply(this, arguments);
+    };
+  }();
+
+  var getTweets = /*#__PURE__*/function () {
+    var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2() {
+      var res, tweetsData;
+      return _regeneratorRuntime().wrap(function _callee2$(_context2) {
+        while (1) {
+          switch (_context2.prev = _context2.next) {
+            case 0:
+              _context2.next = 2;
+              return fetch("/tweets?page=1");
+
+            case 2:
+              res = _context2.sent;
+
+              if (!(res.status === 200)) {
+                _context2.next = 9;
+                break;
+              }
+
+              _context2.next = 6;
+              return res.json();
+
+            case 6:
+              tweetsData = _context2.sent;
+              setNumUsers(tweetsData.tweets.total);
+              setTweets(tweetsData.tweets.data);
+
+            case 9:
+            case "end":
+              return _context2.stop();
+          }
+        }
+      }, _callee2);
+    }));
+
+    return function getTweets() {
+      return _ref2.apply(this, arguments);
+    };
+  }(); // ツイート一覧をtweetsにセット
+
+
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
+    getUsers().then(function () {
+      getTweets();
+    });
+  }, []); // ページネーション時に、追加分を呼び出し
+
+  var handlePaginate = /*#__PURE__*/function () {
+    var _ref3 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee3(page) {
+      var res, tweetsData;
+      return _regeneratorRuntime().wrap(function _callee3$(_context3) {
+        while (1) {
+          switch (_context3.prev = _context3.next) {
+            case 0:
+              _context3.next = 2;
+              return fetch("/tweets?page=".concat(page));
+
+            case 2:
+              res = _context3.sent;
+
+              if (!(res.status === 200)) {
+                _context3.next = 8;
+                break;
+              }
+
+              _context3.next = 6;
+              return res.json();
+
+            case 6:
+              tweetsData = _context3.sent;
+              setTweets(tweetsData.tweets.data);
+
+            case 8:
+            case "end":
+              return _context3.stop();
+          }
+        }
+      }, _callee3);
+    }));
+
+    return function handlePaginate(_x) {
+      return _ref3.apply(this, arguments);
+    };
+  }();
+
+  var tweetItem = tweets.map(function (tweet) {
+    // ツイートユーザーの情報を取得
+    var userData = users.find(function (data) {
+      return data.id === tweet.user_id;
+    });
+    return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("li", {
+      children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("div", {
+        className: "user__item-container",
+        children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_5__.Link, {
+          to: "/tweet-".concat(tweet.id),
+          children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsxs)("div", {
+            className: "d-flex px-2 py-4 w-100",
+            children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)(_parts_UserIcon__WEBPACK_IMPORTED_MODULE_1__.UserIcon, {
+              iconData: {
+                icon: userData.profile_image_path
+              }
+            }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsxs)("div", {
+              className: "ms-2 flex-grow-1",
+              children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("div", {
+                className: "d-flex justify-content-between",
+                children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)(_parts_UserName__WEBPACK_IMPORTED_MODULE_2__.UserName, {
+                  nameData: {
+                    screen_name: userData.screen_name,
+                    user_name: userData.user_name
+                  }
+                })
+              }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("div", {
+                className: "mt-1",
+                children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("p", {
+                  children: tweet.text
+                })
+              })]
+            })]
+          })
+        })
+      })
+    }, tweet.id);
+  });
+  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsxs)("div", {
+    className: "mt-4",
+    children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("div", {
+      className: "border",
+      children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("ul", {
+        children: tweetItem
+      })
+    }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)(_parts_Pagenation__WEBPACK_IMPORTED_MODULE_3__.Pagenation, {
+      sum: numUsers,
+      per: 10,
+      onChange: function onChange(e) {
+        return handlePaginate(e.page);
+      }
+    })]
   });
 };
 

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -8235,7 +8235,7 @@ var UserList = function UserList() {
       setUsers = _useState4[1]; // csrf対策のため、トークンを取得
 
 
-  var csrf_token = document.querySelector('meta[name="csrf-token"]').content; // /authuser 認証ユーザーの情報取得
+  var csrf_token = document.querySelector('meta[name="csrf-token"]').content; // 認証ユーザーの情報取得
 
   var getAuthUserData = /*#__PURE__*/function () {
     var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
@@ -8245,7 +8245,7 @@ var UserList = function UserList() {
           switch (_context.prev = _context.next) {
             case 0:
               _context.next = 2;
-              return fetch("/authuser", {
+              return fetch("/auth-user", {
                 method: "POST",
                 headers: {
                   "Content-Type": "application/json",
@@ -8527,7 +8527,7 @@ var UserProfile = function UserProfile() {
       id = _useParams.id; // csrf対策のため、トークンを取得
 
 
-  var csrf_token = document.querySelector('meta[name="csrf-token"]').content; // /authuser 認証ユーザーの情報取得
+  var csrf_token = document.querySelector('meta[name="csrf-token"]').content; // 認証ユーザーの情報取得
 
   var getAuthUserData = /*#__PURE__*/function () {
     var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
@@ -8537,7 +8537,7 @@ var UserProfile = function UserProfile() {
           switch (_context.prev = _context.next) {
             case 0:
               _context.next = 2;
-              return fetch("/authuser", {
+              return fetch("/auth-user", {
                 method: "POST",
                 headers: {
                   "Content-Type": "application/json",

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -7580,6 +7580,18 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _page_UserProfile__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ./page/UserProfile */ "./resources/js/components/page/UserProfile.jsx");
 /* harmony import */ var _css_app_css__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! ../../css/app.css */ "./resources/css/app.css");
 /* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
 
 
 
@@ -7592,11 +7604,19 @@ __webpack_require__.r(__webpack_exports__);
 
 
 var App = function App() {
+  var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(1),
+      _useState2 = _slicedToArray(_useState, 2),
+      currentPage = _useState2[0],
+      setCurrentPage = _useState2[1];
+
   return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_9__.BrowserRouter, {
     children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_layout_Header__WEBPACK_IMPORTED_MODULE_2__.Header, {}), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Routes, {
       children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Route, {
         path: "/",
-        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_TweetList__WEBPACK_IMPORTED_MODULE_3__.TweetList, {})
+        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_TweetList__WEBPACK_IMPORTED_MODULE_3__.TweetList, {
+          currentPage: currentPage,
+          setCurrentPage: setCurrentPage
+        })
       }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Route, {
         path: "/tweet/:id",
         element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_TweetDetail__WEBPACK_IMPORTED_MODULE_4__.TweetDetail, {})
@@ -7994,7 +8014,10 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 
-var TweetList = function TweetList() {
+var TweetList = function TweetList(props) {
+  var currentPage = props.currentPage,
+      setCurrentPage = props.setCurrentPage;
+
   var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)([]),
       _useState2 = _slicedToArray(_useState, 2),
       users = _useState2[0],
@@ -8019,13 +8042,13 @@ var TweetList = function TweetList() {
           switch (_context.prev = _context.next) {
             case 0:
               _context.next = 2;
-              return fetch("/tweets?page=1");
+              return fetch("/tweets?page=".concat(currentPage));
 
             case 2:
               res = _context.sent;
 
               if (!(res.status === 200)) {
-                _context.next = 10;
+                _context.next = 11;
                 break;
               }
 
@@ -8034,11 +8057,12 @@ var TweetList = function TweetList() {
 
             case 6:
               tweetsData = _context.sent;
+              console.log("aa");
               setUsers(tweetsData.users);
               setNumUsers(tweetsData.tweets.total);
               setTweets(tweetsData.tweets.data);
 
-            case 10:
+            case 11:
             case "end":
               return _context.stop();
           }
@@ -8052,55 +8076,10 @@ var TweetList = function TweetList() {
   }();
 
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
+    console.log("useEffect");
+    console.log(currentPage);
     getTweets();
-  }, []); // ページネーション時に、追加分を呼び出し
-
-  var handlePaginate = /*#__PURE__*/function () {
-    var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2(page) {
-      var res, tweetsData;
-      return _regeneratorRuntime().wrap(function _callee2$(_context2) {
-        while (1) {
-          switch (_context2.prev = _context2.next) {
-            case 0:
-              if (!(page < 1)) {
-                _context2.next = 2;
-                break;
-              }
-
-              return _context2.abrupt("return");
-
-            case 2:
-              _context2.next = 4;
-              return fetch("/tweets?page=".concat(page));
-
-            case 4:
-              res = _context2.sent;
-
-              if (!(res.status === 200)) {
-                _context2.next = 10;
-                break;
-              }
-
-              _context2.next = 8;
-              return res.json();
-
-            case 8:
-              tweetsData = _context2.sent;
-              setTweets(tweetsData.tweets.data);
-
-            case 10:
-            case "end":
-              return _context2.stop();
-          }
-        }
-      }, _callee2);
-    }));
-
-    return function handlePaginate(_x) {
-      return _ref2.apply(this, arguments);
-    };
-  }();
-
+  }, [currentPage]);
   var tweetItem = tweets.map(function (tweet) {
     // ツイートユーザーの情報を取得
     var userData = users.find(function (data) {
@@ -8147,8 +8126,10 @@ var TweetList = function TweetList() {
     }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)(_parts_Pagenation__WEBPACK_IMPORTED_MODULE_3__.Pagenation, {
       sum: numUsers,
       per: 10,
+      currentPage: currentPage,
+      setCurrentPage: setCurrentPage,
       onChange: function onChange(e) {
-        return handlePaginate(e.page);
+        return setCurrentPage(e.page);
       }
     })]
   });
@@ -8977,37 +8958,21 @@ function _toConsumableArray(arr) { return _arrayWithoutHoles(arr) || _iterableTo
 
 function _nonIterableSpread() { throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
 
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
 function _iterableToArray(iter) { if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter); }
 
 function _arrayWithoutHoles(arr) { if (Array.isArray(arr)) return _arrayLikeToArray(arr); }
 
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
-
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
 function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
-function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 
 
 
 var Pagenation = function Pagenation(props) {
-  var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
-      _useState2 = _slicedToArray(_useState, 2),
-      currentPage = _useState2[0],
-      setPage = _useState2[1];
-
-  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
-    props.onChange({
-      page: currentPage
-    });
-  }, [currentPage]); // ページネーションの総数
+  var currentPage = props.currentPage,
+      setCurrentPage = props.setCurrentPage; // ページネーションの総数
 
   var totalPage = Math.ceil(props.sum / props.per); // ボタンで１ページ戻る時
 
@@ -9016,7 +8981,7 @@ var Pagenation = function Pagenation(props) {
       return;
     }
 
-    setPage(currentPage - 1);
+    setCurrentPage(currentPage - 1);
   }; // ボタンで１ページ進む時
 
 
@@ -9025,12 +8990,12 @@ var Pagenation = function Pagenation(props) {
       return;
     }
 
-    setPage(currentPage + 1);
+    setCurrentPage(currentPage + 1);
   }; // ページ番号を直接クリックされたときの処理
 
 
   var handleMove = function handleMove(page) {
-    setPage(page);
+    setCurrentPage(page);
   };
 
   return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_2__.jsx)("div", {

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -8048,7 +8048,7 @@ var TweetList = function TweetList(props) {
               res = _context.sent;
 
               if (!(res.status === 200)) {
-                _context.next = 11;
+                _context.next = 10;
                 break;
               }
 
@@ -8057,12 +8057,11 @@ var TweetList = function TweetList(props) {
 
             case 6:
               tweetsData = _context.sent;
-              console.log("aa");
               setUsers(tweetsData.users);
               setNumUsers(tweetsData.tweets.total);
               setTweets(tweetsData.tweets.data);
 
-            case 11:
+            case 10:
             case "end":
               return _context.stop();
           }
@@ -8076,8 +8075,6 @@ var TweetList = function TweetList(props) {
   }();
 
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
-    console.log("useEffect");
-    console.log(currentPage);
     getTweets();
   }, [currentPage]);
   var tweetItem = tweets.map(function (tweet) {

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -7843,7 +7843,7 @@ var TweetDetail = function TweetDetail() {
 
             case 6:
               tweetData = _context.sent;
-              return _context.abrupt("return", tweetData[0]);
+              return _context.abrupt("return", tweetData);
 
             case 8:
             case "end":
@@ -7856,10 +7856,10 @@ var TweetDetail = function TweetDetail() {
     return function getTweet() {
       return _ref.apply(this, arguments);
     };
-  }(); // ツイート主のユーザー情報を取得
+  }(); // ツイート主のユーザー情報をuserにセット
 
 
-  var getUserData = /*#__PURE__*/function () {
+  var setUserData = /*#__PURE__*/function () {
     var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2(userId) {
       var res, userData;
       return _regeneratorRuntime().wrap(function _callee2$(_context2) {
@@ -7892,21 +7892,22 @@ var TweetDetail = function TweetDetail() {
       }, _callee2);
     }));
 
-    return function getUserData(_x) {
+    return function setUserData(_x) {
       return _ref2.apply(this, arguments);
     };
   }(); // 日付データをyy/mm/ddに加工
 
 
-  var cutPostedDate = function cutPostedDate(dateData) {
+  var editPostedDate = function editPostedDate(dateData) {
     return dateData.split("T")[0].replace(/-/g, "/");
-  };
+  }; // ツイートを取得してから、ユーザー情報を取得
+
 
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
     getTweet().then(function (tweetData) {
-      tweetData.created_at = cutPostedDate(tweetData.created_at);
+      tweetData.created_at = editPostedDate(tweetData.created_at);
       setTweet(tweetData);
-      getUserData(tweetData.user_id);
+      setUserData(tweetData.user_id);
     });
   }, []);
   return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)("div", {
@@ -8030,11 +8031,12 @@ var TweetList = function TweetList() {
   var _useState5 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
       _useState6 = _slicedToArray(_useState5, 2),
       numUsers = _useState6[0],
-      setNumUsers = _useState6[1];
+      setNumUsers = _useState6[1]; // 認証ユーザー以外の全ユーザーを取得
+
 
   var getUsers = /*#__PURE__*/function () {
     var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
-      var res, firstPage;
+      var res, usersData;
       return _regeneratorRuntime().wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
@@ -8054,8 +8056,8 @@ var TweetList = function TweetList() {
               return res.json();
 
             case 6:
-              firstPage = _context.sent;
-              setUsers(firstPage.users.data);
+              usersData = _context.sent;
+              setUsers(usersData.users.data);
 
             case 8:
             case "end":
@@ -8068,7 +8070,8 @@ var TweetList = function TweetList() {
     return function getUsers() {
       return _ref.apply(this, arguments);
     };
-  }();
+  }(); // １ページ目のツイートを取得
+
 
   var getTweets = /*#__PURE__*/function () {
     var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2() {

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -7571,14 +7571,15 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony export */ });
 /* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "./node_modules/react/index.js");
 /* harmony import */ var react_dom__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! react-dom */ "./node_modules/react-dom/index.js");
-/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
-/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router/index.js");
+/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_9__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
+/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_10__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router/index.js");
 /* harmony import */ var _layout_Header__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ./layout/Header */ "./resources/js/components/layout/Header.jsx");
-/* harmony import */ var _page_UserList__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./page/UserList */ "./resources/js/components/page/UserList.jsx");
-/* harmony import */ var _page_TweetList__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./page/TweetList */ "./resources/js/components/page/TweetList.jsx");
-/* harmony import */ var _page_UserProfile__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ./page/UserProfile */ "./resources/js/components/page/UserProfile.jsx");
-/* harmony import */ var _css_app_css__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ../../css/app.css */ "./resources/css/app.css");
-/* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
+/* harmony import */ var _page_TweetList__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! ./page/TweetList */ "./resources/js/components/page/TweetList.jsx");
+/* harmony import */ var _page_TweetDetail__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./page/TweetDetail */ "./resources/js/components/page/TweetDetail.jsx");
+/* harmony import */ var _page_UserList__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ./page/UserList */ "./resources/js/components/page/UserList.jsx");
+/* harmony import */ var _page_UserProfile__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ./page/UserProfile */ "./resources/js/components/page/UserProfile.jsx");
+/* harmony import */ var _css_app_css__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! ../../css/app.css */ "./resources/css/app.css");
+/* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
 function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
 
 function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
@@ -7601,6 +7602,7 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 
+
 var App = function App() {
   //　一覧表示するユーザデータを入れる
   var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)([]),
@@ -7608,27 +7610,30 @@ var App = function App() {
       users = _useState2[0],
       setUsers = _useState2[1];
 
-  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_8__.BrowserRouter, {
-    children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(_layout_Header__WEBPACK_IMPORTED_MODULE_2__.Header, {}), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_9__.Routes, {
-      children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_9__.Route, {
+  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_9__.BrowserRouter, {
+    children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_layout_Header__WEBPACK_IMPORTED_MODULE_2__.Header, {}), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Routes, {
+      children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Route, {
         path: "/",
-        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(_page_TweetList__WEBPACK_IMPORTED_MODULE_4__.TweetList, {})
-      }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_9__.Route, {
+        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_TweetList__WEBPACK_IMPORTED_MODULE_3__.TweetList, {})
+      }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Route, {
+        path: "/tweet/:id",
+        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_TweetDetail__WEBPACK_IMPORTED_MODULE_4__.TweetDetail, {})
+      }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Route, {
         path: "/userList",
-        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(_page_UserList__WEBPACK_IMPORTED_MODULE_3__.UserList, {
+        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_UserList__WEBPACK_IMPORTED_MODULE_5__.UserList, {
           setUsers: setUsers,
           users: users
         })
-      }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_9__.Route, {
-        path: "/profile-:id",
-        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(_page_UserProfile__WEBPACK_IMPORTED_MODULE_5__.UserProfile, {})
+      }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Route, {
+        path: "/profile/:id",
+        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_UserProfile__WEBPACK_IMPORTED_MODULE_6__.UserProfile, {})
       })]
     })]
   });
 };
 
 if (document.getElementById("example")) {
-  react_dom__WEBPACK_IMPORTED_MODULE_1__.render( /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_7__.jsx)(App, {}), document.getElementById("example"));
+  react_dom__WEBPACK_IMPORTED_MODULE_1__.render( /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(App, {}), document.getElementById("example"));
 }
 
 /***/ }),
@@ -7749,6 +7754,217 @@ var Header = function Header() {
             })
           })]
         })
+      })]
+    })
+  });
+};
+
+/***/ }),
+
+/***/ "./resources/js/components/page/TweetDetail.jsx":
+/*!******************************************************!*\
+  !*** ./resources/js/components/page/TweetDetail.jsx ***!
+  \******************************************************/
+/***/ ((__unused_webpack_module, __webpack_exports__, __webpack_require__) => {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export */ __webpack_require__.d(__webpack_exports__, {
+/* harmony export */   "TweetDetail": () => (/* binding */ TweetDetail)
+/* harmony export */ });
+/* harmony import */ var react__WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! react */ "./node_modules/react/index.js");
+/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router/index.js");
+/* harmony import */ var react_router_dom__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! react-router-dom */ "./node_modules/react-router-dom/index.js");
+/* harmony import */ var _parts_UserIcon__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ../parts/UserIcon */ "./resources/js/components/parts/UserIcon.jsx");
+/* harmony import */ var _parts_UserName__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../parts/UserName */ "./resources/js/components/parts/UserName.jsx");
+/* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
+function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
+
+function _regeneratorRuntime() { "use strict"; /*! regenerator-runtime -- Copyright (c) 2014-present, Facebook, Inc. -- license (MIT): https://github.com/facebook/regenerator/blob/main/LICENSE */ _regeneratorRuntime = function _regeneratorRuntime() { return exports; }; var exports = {}, Op = Object.prototype, hasOwn = Op.hasOwnProperty, $Symbol = "function" == typeof Symbol ? Symbol : {}, iteratorSymbol = $Symbol.iterator || "@@iterator", asyncIteratorSymbol = $Symbol.asyncIterator || "@@asyncIterator", toStringTagSymbol = $Symbol.toStringTag || "@@toStringTag"; function define(obj, key, value) { return Object.defineProperty(obj, key, { value: value, enumerable: !0, configurable: !0, writable: !0 }), obj[key]; } try { define({}, ""); } catch (err) { define = function define(obj, key, value) { return obj[key] = value; }; } function wrap(innerFn, outerFn, self, tryLocsList) { var protoGenerator = outerFn && outerFn.prototype instanceof Generator ? outerFn : Generator, generator = Object.create(protoGenerator.prototype), context = new Context(tryLocsList || []); return generator._invoke = function (innerFn, self, context) { var state = "suspendedStart"; return function (method, arg) { if ("executing" === state) throw new Error("Generator is already running"); if ("completed" === state) { if ("throw" === method) throw arg; return doneResult(); } for (context.method = method, context.arg = arg;;) { var delegate = context.delegate; if (delegate) { var delegateResult = maybeInvokeDelegate(delegate, context); if (delegateResult) { if (delegateResult === ContinueSentinel) continue; return delegateResult; } } if ("next" === context.method) context.sent = context._sent = context.arg;else if ("throw" === context.method) { if ("suspendedStart" === state) throw state = "completed", context.arg; context.dispatchException(context.arg); } else "return" === context.method && context.abrupt("return", context.arg); state = "executing"; var record = tryCatch(innerFn, self, context); if ("normal" === record.type) { if (state = context.done ? "completed" : "suspendedYield", record.arg === ContinueSentinel) continue; return { value: record.arg, done: context.done }; } "throw" === record.type && (state = "completed", context.method = "throw", context.arg = record.arg); } }; }(innerFn, self, context), generator; } function tryCatch(fn, obj, arg) { try { return { type: "normal", arg: fn.call(obj, arg) }; } catch (err) { return { type: "throw", arg: err }; } } exports.wrap = wrap; var ContinueSentinel = {}; function Generator() {} function GeneratorFunction() {} function GeneratorFunctionPrototype() {} var IteratorPrototype = {}; define(IteratorPrototype, iteratorSymbol, function () { return this; }); var getProto = Object.getPrototypeOf, NativeIteratorPrototype = getProto && getProto(getProto(values([]))); NativeIteratorPrototype && NativeIteratorPrototype !== Op && hasOwn.call(NativeIteratorPrototype, iteratorSymbol) && (IteratorPrototype = NativeIteratorPrototype); var Gp = GeneratorFunctionPrototype.prototype = Generator.prototype = Object.create(IteratorPrototype); function defineIteratorMethods(prototype) { ["next", "throw", "return"].forEach(function (method) { define(prototype, method, function (arg) { return this._invoke(method, arg); }); }); } function AsyncIterator(generator, PromiseImpl) { function invoke(method, arg, resolve, reject) { var record = tryCatch(generator[method], generator, arg); if ("throw" !== record.type) { var result = record.arg, value = result.value; return value && "object" == _typeof(value) && hasOwn.call(value, "__await") ? PromiseImpl.resolve(value.__await).then(function (value) { invoke("next", value, resolve, reject); }, function (err) { invoke("throw", err, resolve, reject); }) : PromiseImpl.resolve(value).then(function (unwrapped) { result.value = unwrapped, resolve(result); }, function (error) { return invoke("throw", error, resolve, reject); }); } reject(record.arg); } var previousPromise; this._invoke = function (method, arg) { function callInvokeWithMethodAndArg() { return new PromiseImpl(function (resolve, reject) { invoke(method, arg, resolve, reject); }); } return previousPromise = previousPromise ? previousPromise.then(callInvokeWithMethodAndArg, callInvokeWithMethodAndArg) : callInvokeWithMethodAndArg(); }; } function maybeInvokeDelegate(delegate, context) { var method = delegate.iterator[context.method]; if (undefined === method) { if (context.delegate = null, "throw" === context.method) { if (delegate.iterator["return"] && (context.method = "return", context.arg = undefined, maybeInvokeDelegate(delegate, context), "throw" === context.method)) return ContinueSentinel; context.method = "throw", context.arg = new TypeError("The iterator does not provide a 'throw' method"); } return ContinueSentinel; } var record = tryCatch(method, delegate.iterator, context.arg); if ("throw" === record.type) return context.method = "throw", context.arg = record.arg, context.delegate = null, ContinueSentinel; var info = record.arg; return info ? info.done ? (context[delegate.resultName] = info.value, context.next = delegate.nextLoc, "return" !== context.method && (context.method = "next", context.arg = undefined), context.delegate = null, ContinueSentinel) : info : (context.method = "throw", context.arg = new TypeError("iterator result is not an object"), context.delegate = null, ContinueSentinel); } function pushTryEntry(locs) { var entry = { tryLoc: locs[0] }; 1 in locs && (entry.catchLoc = locs[1]), 2 in locs && (entry.finallyLoc = locs[2], entry.afterLoc = locs[3]), this.tryEntries.push(entry); } function resetTryEntry(entry) { var record = entry.completion || {}; record.type = "normal", delete record.arg, entry.completion = record; } function Context(tryLocsList) { this.tryEntries = [{ tryLoc: "root" }], tryLocsList.forEach(pushTryEntry, this), this.reset(!0); } function values(iterable) { if (iterable) { var iteratorMethod = iterable[iteratorSymbol]; if (iteratorMethod) return iteratorMethod.call(iterable); if ("function" == typeof iterable.next) return iterable; if (!isNaN(iterable.length)) { var i = -1, next = function next() { for (; ++i < iterable.length;) { if (hasOwn.call(iterable, i)) return next.value = iterable[i], next.done = !1, next; } return next.value = undefined, next.done = !0, next; }; return next.next = next; } } return { next: doneResult }; } function doneResult() { return { value: undefined, done: !0 }; } return GeneratorFunction.prototype = GeneratorFunctionPrototype, define(Gp, "constructor", GeneratorFunctionPrototype), define(GeneratorFunctionPrototype, "constructor", GeneratorFunction), GeneratorFunction.displayName = define(GeneratorFunctionPrototype, toStringTagSymbol, "GeneratorFunction"), exports.isGeneratorFunction = function (genFun) { var ctor = "function" == typeof genFun && genFun.constructor; return !!ctor && (ctor === GeneratorFunction || "GeneratorFunction" === (ctor.displayName || ctor.name)); }, exports.mark = function (genFun) { return Object.setPrototypeOf ? Object.setPrototypeOf(genFun, GeneratorFunctionPrototype) : (genFun.__proto__ = GeneratorFunctionPrototype, define(genFun, toStringTagSymbol, "GeneratorFunction")), genFun.prototype = Object.create(Gp), genFun; }, exports.awrap = function (arg) { return { __await: arg }; }, defineIteratorMethods(AsyncIterator.prototype), define(AsyncIterator.prototype, asyncIteratorSymbol, function () { return this; }), exports.AsyncIterator = AsyncIterator, exports.async = function (innerFn, outerFn, self, tryLocsList, PromiseImpl) { void 0 === PromiseImpl && (PromiseImpl = Promise); var iter = new AsyncIterator(wrap(innerFn, outerFn, self, tryLocsList), PromiseImpl); return exports.isGeneratorFunction(outerFn) ? iter : iter.next().then(function (result) { return result.done ? result.value : iter.next(); }); }, defineIteratorMethods(Gp), define(Gp, toStringTagSymbol, "Generator"), define(Gp, iteratorSymbol, function () { return this; }), define(Gp, "toString", function () { return "[object Generator]"; }), exports.keys = function (object) { var keys = []; for (var key in object) { keys.push(key); } return keys.reverse(), function next() { for (; keys.length;) { var key = keys.pop(); if (key in object) return next.value = key, next.done = !1, next; } return next.done = !0, next; }; }, exports.values = values, Context.prototype = { constructor: Context, reset: function reset(skipTempReset) { if (this.prev = 0, this.next = 0, this.sent = this._sent = undefined, this.done = !1, this.delegate = null, this.method = "next", this.arg = undefined, this.tryEntries.forEach(resetTryEntry), !skipTempReset) for (var name in this) { "t" === name.charAt(0) && hasOwn.call(this, name) && !isNaN(+name.slice(1)) && (this[name] = undefined); } }, stop: function stop() { this.done = !0; var rootRecord = this.tryEntries[0].completion; if ("throw" === rootRecord.type) throw rootRecord.arg; return this.rval; }, dispatchException: function dispatchException(exception) { if (this.done) throw exception; var context = this; function handle(loc, caught) { return record.type = "throw", record.arg = exception, context.next = loc, caught && (context.method = "next", context.arg = undefined), !!caught; } for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i], record = entry.completion; if ("root" === entry.tryLoc) return handle("end"); if (entry.tryLoc <= this.prev) { var hasCatch = hasOwn.call(entry, "catchLoc"), hasFinally = hasOwn.call(entry, "finallyLoc"); if (hasCatch && hasFinally) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } else if (hasCatch) { if (this.prev < entry.catchLoc) return handle(entry.catchLoc, !0); } else { if (!hasFinally) throw new Error("try statement without catch or finally"); if (this.prev < entry.finallyLoc) return handle(entry.finallyLoc); } } } }, abrupt: function abrupt(type, arg) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc <= this.prev && hasOwn.call(entry, "finallyLoc") && this.prev < entry.finallyLoc) { var finallyEntry = entry; break; } } finallyEntry && ("break" === type || "continue" === type) && finallyEntry.tryLoc <= arg && arg <= finallyEntry.finallyLoc && (finallyEntry = null); var record = finallyEntry ? finallyEntry.completion : {}; return record.type = type, record.arg = arg, finallyEntry ? (this.method = "next", this.next = finallyEntry.finallyLoc, ContinueSentinel) : this.complete(record); }, complete: function complete(record, afterLoc) { if ("throw" === record.type) throw record.arg; return "break" === record.type || "continue" === record.type ? this.next = record.arg : "return" === record.type ? (this.rval = this.arg = record.arg, this.method = "return", this.next = "end") : "normal" === record.type && afterLoc && (this.next = afterLoc), ContinueSentinel; }, finish: function finish(finallyLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.finallyLoc === finallyLoc) return this.complete(entry.completion, entry.afterLoc), resetTryEntry(entry), ContinueSentinel; } }, "catch": function _catch(tryLoc) { for (var i = this.tryEntries.length - 1; i >= 0; --i) { var entry = this.tryEntries[i]; if (entry.tryLoc === tryLoc) { var record = entry.completion; if ("throw" === record.type) { var thrown = record.arg; resetTryEntry(entry); } return thrown; } } throw new Error("illegal catch attempt"); }, delegateYield: function delegateYield(iterable, resultName, nextLoc) { return this.delegate = { iterator: values(iterable), resultName: resultName, nextLoc: nextLoc }, "next" === this.method && (this.arg = undefined), ContinueSentinel; } }, exports; }
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
+
+function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
+
+function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
+
+function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
+
+function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
+
+function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
+
+
+
+
+
+
+
+var TweetDetail = function TweetDetail() {
+  var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)({}),
+      _useState2 = _slicedToArray(_useState, 2),
+      tweet = _useState2[0],
+      setTweet = _useState2[1];
+
+  var _useState3 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)({}),
+      _useState4 = _slicedToArray(_useState3, 2),
+      user = _useState4[0],
+      setUser = _useState4[1]; // urlからユーザーIDの取得
+
+
+  var _useParams = (0,react_router_dom__WEBPACK_IMPORTED_MODULE_4__.useParams)(),
+      id = _useParams.id; // 指定のツイートを取得
+
+
+  var getTweet = /*#__PURE__*/function () {
+    var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
+      var res, tweetData;
+      return _regeneratorRuntime().wrap(function _callee$(_context) {
+        while (1) {
+          switch (_context.prev = _context.next) {
+            case 0:
+              _context.next = 2;
+              return fetch("/tweet-".concat(id));
+
+            case 2:
+              res = _context.sent;
+
+              if (!(res.status === 200)) {
+                _context.next = 8;
+                break;
+              }
+
+              _context.next = 6;
+              return res.json();
+
+            case 6:
+              tweetData = _context.sent;
+              return _context.abrupt("return", tweetData[0]);
+
+            case 8:
+            case "end":
+              return _context.stop();
+          }
+        }
+      }, _callee);
+    }));
+
+    return function getTweet() {
+      return _ref.apply(this, arguments);
+    };
+  }(); // ツイート主のユーザー情報を取得
+
+
+  var getUserData = /*#__PURE__*/function () {
+    var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2(userId) {
+      var res, userData;
+      return _regeneratorRuntime().wrap(function _callee2$(_context2) {
+        while (1) {
+          switch (_context2.prev = _context2.next) {
+            case 0:
+              _context2.next = 2;
+              return fetch("/user-".concat(userId));
+
+            case 2:
+              res = _context2.sent;
+
+              if (!(res.status === 200)) {
+                _context2.next = 8;
+                break;
+              }
+
+              _context2.next = 6;
+              return res.json();
+
+            case 6:
+              userData = _context2.sent;
+              setUser(userData);
+
+            case 8:
+            case "end":
+              return _context2.stop();
+          }
+        }
+      }, _callee2);
+    }));
+
+    return function getUserData(_x) {
+      return _ref2.apply(this, arguments);
+    };
+  }(); // 日付データをyy/mm/ddに加工
+
+
+  var cutPostedDate = function cutPostedDate(dateData) {
+    return dateData.split("T")[0].replace(/-/g, "/");
+  };
+
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
+    getTweet().then(function (tweetData) {
+      tweetData.created_at = cutPostedDate(tweetData.created_at);
+      setTweet(tweetData);
+      getUserData(tweetData.user_id);
+    });
+  }, []);
+  return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)("div", {
+    className: "container-lg mt-5",
+    children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsxs)("div", {
+      className: "border",
+      children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsxs)("div", {
+        className: "d-flex align-items-center",
+        children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_5__.Link, {
+          to: "/",
+          children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)("button", {
+            className: "btn",
+            children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)("svg", {
+              viewBox: "0 0 16 16",
+              width: "16",
+              height: "16",
+              xmlns: "http://www.w3.org/2000/svg",
+              fill: "#111111",
+              className: "bi bi-arrow-left",
+              children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)("path", {
+                d: "M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z"
+              })
+            })
+          })
+        }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)("div", {
+          className: "ms-3",
+          children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)("h2", {
+            children: "\u30C4\u30A4\u30FC\u30C8"
+          })
+        })]
+      }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsxs)("div", {
+        className: "py-1 px-2",
+        children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsxs)("div", {
+          className: "d-flex",
+          children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)(_parts_UserIcon__WEBPACK_IMPORTED_MODULE_1__.UserIcon, {
+            userList: false,
+            iconData: {
+              icon: user.profile_image_path
+            }
+          }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)("div", {
+            className: "ms-2",
+            children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)(_parts_UserName__WEBPACK_IMPORTED_MODULE_2__.UserName, {
+              isUserProfile: true,
+              nameData: {
+                screen_name: user.screen_name,
+                user_name: user.user_name
+              }
+            })
+          })]
+        }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsxs)("div", {
+          className: "my-2",
+          children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)("p", {
+            children: tweet.text
+          }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsxs)("p", {
+            className: "pt-2",
+            children: ["\u6295\u7A3F\u65E5: ", tweet.created_at]
+          })]
+        })]
       })]
     })
   });
@@ -7947,7 +8163,7 @@ var TweetList = function TweetList() {
       children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("div", {
         className: "user__item-container",
         children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_5__.Link, {
-          to: "/tweet-".concat(tweet.id),
+          to: "/tweet/".concat(tweet.id),
           children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsxs)("div", {
             className: "d-flex px-2 py-4 w-100",
             children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)(_parts_UserIcon__WEBPACK_IMPORTED_MODULE_1__.UserIcon, {
@@ -8227,7 +8443,7 @@ var UserList = function UserList() {
       children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)("div", {
         className: "user__item-container",
         children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_6__.Link, {
-          to: "/profile-".concat(item.id),
+          to: "/profile/".concat(item.id),
           children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
             className: "d-flex px-2 py-4 w-100",
             children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_UserIcon__WEBPACK_IMPORTED_MODULE_3__.UserIcon, {

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -7580,18 +7580,6 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _page_UserProfile__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ./page/UserProfile */ "./resources/js/components/page/UserProfile.jsx");
 /* harmony import */ var _css_app_css__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! ../../css/app.css */ "./resources/css/app.css");
 /* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
-
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
-function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
 
 
 
@@ -7604,19 +7592,11 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 var App = function App() {
-  var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(1),
-      _useState2 = _slicedToArray(_useState, 2),
-      currentPage = _useState2[0],
-      setCurrentPage = _useState2[1];
-
   return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_9__.BrowserRouter, {
     children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_layout_Header__WEBPACK_IMPORTED_MODULE_2__.Header, {}), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Routes, {
       children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Route, {
         path: "/",
-        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_TweetList__WEBPACK_IMPORTED_MODULE_3__.TweetList, {
-          currentPage: currentPage,
-          setCurrentPage: setCurrentPage
-        })
+        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_TweetList__WEBPACK_IMPORTED_MODULE_3__.TweetList, {})
       }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Route, {
         path: "/tweet/:id",
         element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_TweetDetail__WEBPACK_IMPORTED_MODULE_4__.TweetDetail, {})
@@ -8014,24 +7994,26 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 
-var TweetList = function TweetList(props) {
-  var currentPage = props.currentPage,
-      setCurrentPage = props.setCurrentPage;
-
-  var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)([]),
+var TweetList = function TweetList() {
+  var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(1),
       _useState2 = _slicedToArray(_useState, 2),
-      users = _useState2[0],
-      setUsers = _useState2[1];
+      currentPage = _useState2[0],
+      setCurrentPage = _useState2[1];
 
   var _useState3 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)([]),
       _useState4 = _slicedToArray(_useState3, 2),
-      tweets = _useState4[0],
-      setTweets = _useState4[1];
+      users = _useState4[0],
+      setUsers = _useState4[1];
 
-  var _useState5 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
+  var _useState5 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)([]),
       _useState6 = _slicedToArray(_useState5, 2),
-      numUsers = _useState6[0],
-      setNumUsers = _useState6[1]; // １ページ目のツイートを取得
+      tweets = _useState6[0],
+      setTweets = _useState6[1];
+
+  var _useState7 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
+      _useState8 = _slicedToArray(_useState7, 2),
+      numUsers = _useState8[0],
+      setNumUsers = _useState8[1]; // １ページ目のツイートを取得
 
 
   var getTweets = /*#__PURE__*/function () {

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -7944,9 +7944,7 @@ var TweetDetail = function TweetDetail() {
           className: "d-flex",
           children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)(_parts_UserIcon__WEBPACK_IMPORTED_MODULE_1__.UserIcon, {
             userList: false,
-            iconData: {
-              icon: user.profile_image_path
-            }
+            iconData: user.profile_image_path
           }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)("div", {
             className: "ms-2",
             children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_3__.jsx)(_parts_UserName__WEBPACK_IMPORTED_MODULE_2__.UserName, {
@@ -8031,24 +8029,24 @@ var TweetList = function TweetList() {
   var _useState5 = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)(0),
       _useState6 = _slicedToArray(_useState5, 2),
       numUsers = _useState6[0],
-      setNumUsers = _useState6[1]; // 認証ユーザー以外の全ユーザーを取得
+      setNumUsers = _useState6[1]; // １ページ目のツイートを取得
 
 
-  var getUsers = /*#__PURE__*/function () {
+  var getTweets = /*#__PURE__*/function () {
     var _ref = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee() {
-      var res, usersData;
+      var res, tweetsData;
       return _regeneratorRuntime().wrap(function _callee$(_context) {
         while (1) {
           switch (_context.prev = _context.next) {
             case 0:
               _context.next = 2;
-              return fetch("/users");
+              return fetch("/tweets?page=1");
 
             case 2:
               res = _context.sent;
 
               if (!(res.status === 200)) {
-                _context.next = 8;
+                _context.next = 10;
                 break;
               }
 
@@ -8056,10 +8054,12 @@ var TweetList = function TweetList() {
               return res.json();
 
             case 6:
-              usersData = _context.sent;
-              setUsers(usersData.users.data);
+              tweetsData = _context.sent;
+              setUsers(tweetsData.users);
+              setNumUsers(tweetsData.tweets.total);
+              setTweets(tweetsData.tweets.data);
 
-            case 8:
+            case 10:
             case "end":
               return _context.stop();
           }
@@ -8067,27 +8067,31 @@ var TweetList = function TweetList() {
       }, _callee);
     }));
 
-    return function getUsers() {
+    return function getTweets() {
       return _ref.apply(this, arguments);
     };
-  }(); // １ページ目のツイートを取得
+  }(); // ツイート一覧をtweetsにセット
 
 
-  var getTweets = /*#__PURE__*/function () {
-    var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2() {
+  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
+    getTweets();
+  }, []); // ページネーション時に、追加分を呼び出し
+
+  var handlePaginate = /*#__PURE__*/function () {
+    var _ref2 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee2(page) {
       var res, tweetsData;
       return _regeneratorRuntime().wrap(function _callee2$(_context2) {
         while (1) {
           switch (_context2.prev = _context2.next) {
             case 0:
               _context2.next = 2;
-              return fetch("/tweets?page=1");
+              return fetch("/tweets?page=".concat(page));
 
             case 2:
               res = _context2.sent;
 
               if (!(res.status === 200)) {
-                _context2.next = 9;
+                _context2.next = 8;
                 break;
               }
 
@@ -8096,10 +8100,9 @@ var TweetList = function TweetList() {
 
             case 6:
               tweetsData = _context2.sent;
-              setNumUsers(tweetsData.tweets.total);
               setTweets(tweetsData.tweets.data);
 
-            case 9:
+            case 8:
             case "end":
               return _context2.stop();
           }
@@ -8107,53 +8110,8 @@ var TweetList = function TweetList() {
       }, _callee2);
     }));
 
-    return function getTweets() {
-      return _ref2.apply(this, arguments);
-    };
-  }(); // ツイート一覧をtweetsにセット
-
-
-  (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
-    getUsers().then(function () {
-      getTweets();
-    });
-  }, []); // ページネーション時に、追加分を呼び出し
-
-  var handlePaginate = /*#__PURE__*/function () {
-    var _ref3 = _asyncToGenerator( /*#__PURE__*/_regeneratorRuntime().mark(function _callee3(page) {
-      var res, tweetsData;
-      return _regeneratorRuntime().wrap(function _callee3$(_context3) {
-        while (1) {
-          switch (_context3.prev = _context3.next) {
-            case 0:
-              _context3.next = 2;
-              return fetch("/tweets?page=".concat(page));
-
-            case 2:
-              res = _context3.sent;
-
-              if (!(res.status === 200)) {
-                _context3.next = 8;
-                break;
-              }
-
-              _context3.next = 6;
-              return res.json();
-
-            case 6:
-              tweetsData = _context3.sent;
-              setTweets(tweetsData.tweets.data);
-
-            case 8:
-            case "end":
-              return _context3.stop();
-          }
-        }
-      }, _callee3);
-    }));
-
     return function handlePaginate(_x) {
-      return _ref3.apply(this, arguments);
+      return _ref2.apply(this, arguments);
     };
   }();
 
@@ -8162,6 +8120,7 @@ var TweetList = function TweetList() {
     var userData = users.find(function (data) {
       return data.id === tweet.user_id;
     });
+    console.log(userData);
     return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("li", {
       children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("div", {
         className: "user__item-container",
@@ -8170,9 +8129,7 @@ var TweetList = function TweetList() {
           children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsxs)("div", {
             className: "d-flex px-2 py-4 w-100",
             children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)(_parts_UserIcon__WEBPACK_IMPORTED_MODULE_1__.UserIcon, {
-              iconData: {
-                icon: userData.profile_image_path
-              }
+              iconData: userData.profile_image_path ? userData.profile_image_path : "no-image.png"
             }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsxs)("div", {
               className: "ms-2 flex-grow-1",
               children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("div", {
@@ -8450,9 +8407,7 @@ var UserList = function UserList() {
           children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
             className: "d-flex px-2 py-4 w-100",
             children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_UserIcon__WEBPACK_IMPORTED_MODULE_3__.UserIcon, {
-              iconData: {
-                icon: item.profile_image_path
-              }
+              iconData: item.profile_image_path
             }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
               className: "ms-2 flex-grow-1",
               children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
@@ -8745,10 +8700,7 @@ var UserProfile = function UserProfile() {
             children: profileButton()
           }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_UserIcon__WEBPACK_IMPORTED_MODULE_3__.UserIcon, {
             userList: false,
-            iconData: {
-              icon: user.icon,
-              desc: user.iconDesc
-            }
+            iconData: user.icon
           })]
         }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
           children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(_parts_UserName__WEBPACK_IMPORTED_MODULE_4__.UserName, {
@@ -9168,7 +9120,7 @@ var UserIcon = function UserIcon(props) {
       className: "w-100 h-100 overflow-hidden rounded-circle border",
       children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_1__.jsx)("img", {
         className: "w-100 h-100",
-        src: "/images/".concat(props.iconData.icon),
+        src: "/images/".concat(props.iconData),
         alt: "\u30E6\u30FC\u30B6\u30A2\u30A4\u30B3\u30F3"
       })
     })

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -8105,8 +8105,7 @@ var TweetList = function TweetList() {
     // ツイートユーザーの情報を取得
     var userData = users.find(function (data) {
       return data.id === tweet.user_id;
-    }); // console.log(userData);
-
+    });
     return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("li", {
       children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("div", {
         className: "user__item-container",

--- a/src/public/js/app.js
+++ b/src/public/js/app.js
@@ -7580,18 +7580,6 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _page_UserProfile__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ./page/UserProfile */ "./resources/js/components/page/UserProfile.jsx");
 /* harmony import */ var _css_app_css__WEBPACK_IMPORTED_MODULE_7__ = __webpack_require__(/*! ../../css/app.css */ "./resources/css/app.css");
 /* harmony import */ var react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__ = __webpack_require__(/*! react/jsx-runtime */ "./node_modules/react/jsx-runtime.js");
-function _slicedToArray(arr, i) { return _arrayWithHoles(arr) || _iterableToArrayLimit(arr, i) || _unsupportedIterableToArray(arr, i) || _nonIterableRest(); }
-
-function _nonIterableRest() { throw new TypeError("Invalid attempt to destructure non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."); }
-
-function _unsupportedIterableToArray(o, minLen) { if (!o) return; if (typeof o === "string") return _arrayLikeToArray(o, minLen); var n = Object.prototype.toString.call(o).slice(8, -1); if (n === "Object" && o.constructor) n = o.constructor.name; if (n === "Map" || n === "Set") return Array.from(o); if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen); }
-
-function _arrayLikeToArray(arr, len) { if (len == null || len > arr.length) len = arr.length; for (var i = 0, arr2 = new Array(len); i < len; i++) { arr2[i] = arr[i]; } return arr2; }
-
-function _iterableToArrayLimit(arr, i) { var _i = arr == null ? null : typeof Symbol !== "undefined" && arr[Symbol.iterator] || arr["@@iterator"]; if (_i == null) return; var _arr = []; var _n = true; var _d = false; var _s, _e; try { for (_i = _i.call(arr); !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"] != null) _i["return"](); } finally { if (_d) throw _e; } } return _arr; }
-
-function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
-
 
 
 
@@ -7604,12 +7592,6 @@ function _arrayWithHoles(arr) { if (Array.isArray(arr)) return arr; }
 
 
 var App = function App() {
-  //　一覧表示するユーザデータを入れる
-  var _useState = (0,react__WEBPACK_IMPORTED_MODULE_0__.useState)([]),
-      _useState2 = _slicedToArray(_useState, 2),
-      users = _useState2[0],
-      setUsers = _useState2[1];
-
   return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_9__.BrowserRouter, {
     children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_layout_Header__WEBPACK_IMPORTED_MODULE_2__.Header, {}), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsxs)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Routes, {
       children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Route, {
@@ -7620,10 +7602,7 @@ var App = function App() {
         element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_TweetDetail__WEBPACK_IMPORTED_MODULE_4__.TweetDetail, {})
       }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Route, {
         path: "/userList",
-        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_UserList__WEBPACK_IMPORTED_MODULE_5__.UserList, {
-          setUsers: setUsers,
-          users: users
-        })
+        element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_UserList__WEBPACK_IMPORTED_MODULE_5__.UserList, {})
       }), /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_10__.Route, {
         path: "/profile/:id",
         element: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_8__.jsx)(_page_UserProfile__WEBPACK_IMPORTED_MODULE_6__.UserProfile, {})
@@ -7828,7 +7807,7 @@ var TweetDetail = function TweetDetail() {
           switch (_context.prev = _context.next) {
             case 0:
               _context.next = 2;
-              return fetch("/tweet-".concat(id));
+              return fetch("/tweets/".concat(id));
 
             case 2:
               res = _context.sent;
@@ -7867,7 +7846,7 @@ var TweetDetail = function TweetDetail() {
           switch (_context2.prev = _context2.next) {
             case 0:
               _context2.next = 2;
-              return fetch("/user-".concat(userId));
+              return fetch("/users/".concat(userId));
 
             case 2:
               res = _context2.sent;
@@ -8070,8 +8049,7 @@ var TweetList = function TweetList() {
     return function getTweets() {
       return _ref.apply(this, arguments);
     };
-  }(); // ツイート一覧をtweetsにセット
-
+  }();
 
   (0,react__WEBPACK_IMPORTED_MODULE_0__.useEffect)(function () {
     getTweets();
@@ -8084,25 +8062,33 @@ var TweetList = function TweetList() {
         while (1) {
           switch (_context2.prev = _context2.next) {
             case 0:
-              _context2.next = 2;
-              return fetch("/tweets?page=".concat(page));
-
-            case 2:
-              res = _context2.sent;
-
-              if (!(res.status === 200)) {
-                _context2.next = 8;
+              if (!(page < 1)) {
+                _context2.next = 2;
                 break;
               }
 
-              _context2.next = 6;
+              return _context2.abrupt("return");
+
+            case 2:
+              _context2.next = 4;
+              return fetch("/tweets?page=".concat(page));
+
+            case 4:
+              res = _context2.sent;
+
+              if (!(res.status === 200)) {
+                _context2.next = 10;
+                break;
+              }
+
+              _context2.next = 8;
               return res.json();
 
-            case 6:
+            case 8:
               tweetsData = _context2.sent;
               setTweets(tweetsData.tweets.data);
 
-            case 8:
+            case 10:
             case "end":
               return _context2.stop();
           }
@@ -8119,8 +8105,8 @@ var TweetList = function TweetList() {
     // ツイートユーザーの情報を取得
     var userData = users.find(function (data) {
       return data.id === tweet.user_id;
-    });
-    console.log(userData);
+    }); // console.log(userData);
+
     return /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("li", {
       children: /*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_4__.jsx)("div", {
         className: "user__item-container",
@@ -8598,7 +8584,7 @@ var UserProfile = function UserProfile() {
           switch (_context2.prev = _context2.next) {
             case 0:
               _context2.next = 2;
-              return fetch("/user-".concat(id));
+              return fetch("/users/".concat(id));
 
             case 2:
               res = _context2.sent;
@@ -8654,9 +8640,6 @@ var UserProfile = function UserProfile() {
     children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
       className: "border",
       children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
-        onClick: function onClick() {
-          return console.log(isFollowing);
-        },
         children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsxs)("div", {
           className: "d-flex p-1",
           children: [/*#__PURE__*/(0,react_jsx_runtime__WEBPACK_IMPORTED_MODULE_5__.jsx)(react_router_dom__WEBPACK_IMPORTED_MODULE_7__.Link, {

--- a/src/resources/js/components/App.jsx
+++ b/src/resources/js/components/App.jsx
@@ -11,19 +11,13 @@ import { UserProfile } from "./page/UserProfile";
 import "../../css/app.css";
 
 export const App = () => {
-    //　一覧表示するユーザデータを入れる
-    const [users, setUsers] = useState([]);
-
     return (
         <BrowserRouter>
             <Header />
             <Routes>
                 <Route path={`/`} element={<TweetList />} />
                 <Route path="/tweet/:id" element={<TweetDetail />} />
-                <Route
-                    path="/userList"
-                    element={<UserList setUsers={setUsers} users={users} />}
-                />
+                <Route path="/userList" element={<UserList />} />
                 <Route path={`/profile/:id`} element={<UserProfile />} />
             </Routes>
         </BrowserRouter>

--- a/src/resources/js/components/App.jsx
+++ b/src/resources/js/components/App.jsx
@@ -2,30 +2,32 @@ import React, { useState } from "react";
 import ReactDOM from "react-dom";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
-import { UserList } from "./page/UserList";
-import { UserProfile } from "./page/UserProfile";
 import { Header } from "./layout/Header";
+import { UserList } from "./page/UserList";
+import { TweetList } from "./page/TweetList";
+import { UserProfile } from "./page/UserProfile";
 
 import "../../css/app.css";
 
 export const App = () => {
-    //　一覧表示するユーザデータを入れる
-    const [users, setUsers] = useState([]);
+  //　一覧表示するユーザデータを入れる
+  const [users, setUsers] = useState([]);
 
-    return (
-        <BrowserRouter>
-            <Header />
-            <Routes>
-                <Route
-                    path="/userList"
-                    element={<UserList setUsers={setUsers} users={users} />}
-                />
-                <Route path={`/profile/:id`} element={<UserProfile />} />
-            </Routes>
-        </BrowserRouter>
-    );
+  return (
+    <BrowserRouter>
+      <Header />
+      <Routes>
+        <Route path={`/`} element={<TweetList />} />
+        <Route
+          path="/userList"
+          element={<UserList setUsers={setUsers} users={users} />}
+        />
+        <Route path={`/profile-:id`} element={<UserProfile />} />
+      </Routes>
+    </BrowserRouter>
+  );
 };
 
 if (document.getElementById("example")) {
-    ReactDOM.render(<App />, document.getElementById("example"));
+  ReactDOM.render(<App />, document.getElementById("example"));
 }

--- a/src/resources/js/components/App.jsx
+++ b/src/resources/js/components/App.jsx
@@ -11,14 +11,23 @@ import { UserProfile } from "./page/UserProfile";
 import "../../css/app.css";
 
 export const App = () => {
+    const [currentPage, setCurrentPage] = useState(1);
     return (
         <BrowserRouter>
             <Header />
             <Routes>
-                <Route path={`/`} element={<TweetList />} />
+                <Route
+                    path="/"
+                    element={
+                        <TweetList
+                            currentPage={currentPage}
+                            setCurrentPage={setCurrentPage}
+                        />
+                    }
+                />
                 <Route path="/tweet/:id" element={<TweetDetail />} />
                 <Route path="/userList" element={<UserList />} />
-                <Route path={`/profile/:id`} element={<UserProfile />} />
+                <Route path="/profile/:id" element={<UserProfile />} />
             </Routes>
         </BrowserRouter>
     );

--- a/src/resources/js/components/App.jsx
+++ b/src/resources/js/components/App.jsx
@@ -11,20 +11,11 @@ import { UserProfile } from "./page/UserProfile";
 import "../../css/app.css";
 
 export const App = () => {
-    const [currentPage, setCurrentPage] = useState(1);
     return (
         <BrowserRouter>
             <Header />
             <Routes>
-                <Route
-                    path="/"
-                    element={
-                        <TweetList
-                            currentPage={currentPage}
-                            setCurrentPage={setCurrentPage}
-                        />
-                    }
-                />
+                <Route path="/" element={<TweetList />} />
                 <Route path="/tweet/:id" element={<TweetDetail />} />
                 <Route path="/userList" element={<UserList />} />
                 <Route path="/profile/:id" element={<UserProfile />} />

--- a/src/resources/js/components/App.jsx
+++ b/src/resources/js/components/App.jsx
@@ -3,31 +3,33 @@ import ReactDOM from "react-dom";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 
 import { Header } from "./layout/Header";
-import { UserList } from "./page/UserList";
 import { TweetList } from "./page/TweetList";
+import { TweetDetail } from "./page/TweetDetail";
+import { UserList } from "./page/UserList";
 import { UserProfile } from "./page/UserProfile";
 
 import "../../css/app.css";
 
 export const App = () => {
-  //　一覧表示するユーザデータを入れる
-  const [users, setUsers] = useState([]);
+    //　一覧表示するユーザデータを入れる
+    const [users, setUsers] = useState([]);
 
-  return (
-    <BrowserRouter>
-      <Header />
-      <Routes>
-        <Route path={`/`} element={<TweetList />} />
-        <Route
-          path="/userList"
-          element={<UserList setUsers={setUsers} users={users} />}
-        />
-        <Route path={`/profile-:id`} element={<UserProfile />} />
-      </Routes>
-    </BrowserRouter>
-  );
+    return (
+        <BrowserRouter>
+            <Header />
+            <Routes>
+                <Route path={`/`} element={<TweetList />} />
+                <Route path="/tweet/:id" element={<TweetDetail />} />
+                <Route
+                    path="/userList"
+                    element={<UserList setUsers={setUsers} users={users} />}
+                />
+                <Route path={`/profile/:id`} element={<UserProfile />} />
+            </Routes>
+        </BrowserRouter>
+    );
 };
 
 if (document.getElementById("example")) {
-  ReactDOM.render(<App />, document.getElementById("example"));
+    ReactDOM.render(<App />, document.getElementById("example"));
 }

--- a/src/resources/js/components/page/TweetDetail.jsx
+++ b/src/resources/js/components/page/TweetDetail.jsx
@@ -13,7 +13,7 @@ export const TweetDetail = () => {
 
     // 指定のツイートを取得
     const getTweet = async () => {
-        const res = await fetch(`/tweet-${id}`);
+        const res = await fetch(`/tweets/${id}`);
         if (res.status === 200) {
             const tweetData = await res.json();
             return tweetData;
@@ -22,7 +22,7 @@ export const TweetDetail = () => {
 
     // ツイート主のユーザー情報をuserにセット
     const setUserData = async (userId) => {
-        const res = await fetch(`/user-${userId}`);
+        const res = await fetch(`/users/${userId}`);
         if (res.status === 200) {
             const userData = await res.json();
             setUser(userData);

--- a/src/resources/js/components/page/TweetDetail.jsx
+++ b/src/resources/js/components/page/TweetDetail.jsx
@@ -16,12 +16,12 @@ export const TweetDetail = () => {
         const res = await fetch(`/tweet-${id}`);
         if (res.status === 200) {
             const tweetData = await res.json();
-            return tweetData[0];
+            return tweetData;
         }
     };
 
-    // ツイート主のユーザー情報を取得
-    const getUserData = async (userId) => {
+    // ツイート主のユーザー情報をuserにセット
+    const setUserData = async (userId) => {
         const res = await fetch(`/user-${userId}`);
         if (res.status === 200) {
             const userData = await res.json();
@@ -30,16 +30,17 @@ export const TweetDetail = () => {
     };
 
     // 日付データをyy/mm/ddに加工
-    const cutPostedDate = (dateData) => {
+    const editPostedDate = (dateData) => {
         return dateData.split("T")[0].replace(/-/g, "/");
     };
 
+    // ツイートを取得してから、ユーザー情報を取得
     useEffect(() => {
         getTweet().then((tweetData) => {
-            tweetData.created_at = cutPostedDate(tweetData.created_at);
+            tweetData.created_at = editPostedDate(tweetData.created_at);
             setTweet(tweetData);
 
-            getUserData(tweetData.user_id);
+            setUserData(tweetData.user_id);
         });
     }, []);
 

--- a/src/resources/js/components/page/TweetDetail.jsx
+++ b/src/resources/js/components/page/TweetDetail.jsx
@@ -70,9 +70,7 @@ export const TweetDetail = () => {
                     <div className="d-flex">
                         <UserIcon
                             userList={false}
-                            iconData={{
-                                icon: user.profile_image_path,
-                            }}
+                            iconData={user.profile_image_path}
                         />
                         <div className="ms-2">
                             <UserName

--- a/src/resources/js/components/page/TweetDetail.jsx
+++ b/src/resources/js/components/page/TweetDetail.jsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { UserIcon } from "../parts/UserIcon";
+import { UserName } from "../parts/UserName";
+
+export const TweetDetail = () => {
+    const [tweet, setTweet] = useState({});
+    const [user, setUser] = useState({});
+
+    // urlからユーザーIDの取得
+    const { id } = useParams();
+
+    // 指定のツイートを取得
+    const getTweet = async () => {
+        const res = await fetch(`/tweet-${id}`);
+        if (res.status === 200) {
+            const tweetData = await res.json();
+            return tweetData[0];
+        }
+    };
+
+    // ツイート主のユーザー情報を取得
+    const getUserData = async (userId) => {
+        const res = await fetch(`/user-${userId}`);
+        if (res.status === 200) {
+            const userData = await res.json();
+            setUser(userData);
+        }
+    };
+
+    // 日付データをyy/mm/ddに加工
+    const cutPostedDate = (dateData) => {
+        return dateData.split("T")[0].replace(/-/g, "/");
+    };
+
+    useEffect(() => {
+        getTweet().then((tweetData) => {
+            tweetData.created_at = cutPostedDate(tweetData.created_at);
+            setTweet(tweetData);
+
+            getUserData(tweetData.user_id);
+        });
+    }, []);
+
+    return (
+        <div className="container-lg mt-5">
+            <div className="border">
+                <div className="d-flex align-items-center">
+                    <Link to="/">
+                        <button className="btn">
+                            <svg
+                                viewBox="0 0 16 16"
+                                width="16"
+                                height="16"
+                                xmlns="http://www.w3.org/2000/svg"
+                                fill="#111111"
+                                className="bi bi-arrow-left"
+                            >
+                                <path d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8z" />
+                            </svg>
+                        </button>
+                    </Link>
+                    <div className="ms-3">
+                        <h2>ツイート</h2>
+                    </div>
+                </div>
+                <div className="py-1 px-2">
+                    <div className="d-flex">
+                        <UserIcon
+                            userList={false}
+                            iconData={{
+                                icon: user.profile_image_path,
+                            }}
+                        />
+                        <div className="ms-2">
+                            <UserName
+                                isUserProfile={true}
+                                nameData={{
+                                    screen_name: user.screen_name,
+                                    user_name: user.user_name,
+                                }}
+                            />
+                        </div>
+                    </div>
+                    <div className="my-2">
+                        <p>{tweet.text}</p>
+                        <p className="pt-2">投稿日: {tweet.created_at}</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/src/resources/js/components/page/TweetList.jsx
+++ b/src/resources/js/components/page/TweetList.jsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import { UserIcon } from "../parts/UserIcon";
+import { UserName } from "../parts/UserName";
+import { Pagenation } from "../parts/Pagenation";
+
+export const TweetList = () => {
+    const [users, setUsers] = useState([]);
+    const [tweets, setTweets] = useState([]);
+    const [numUsers, setNumUsers] = useState(0);
+
+    const getUsers = async () => {
+        const res = await fetch("/users");
+        if (res.status === 200) {
+            const firstPage = await res.json();
+            setUsers(firstPage.users.data);
+        }
+    };
+
+    const getTweets = async () => {
+        const res = await fetch("/tweets?page=1");
+        if (res.status === 200) {
+            const tweetsData = await res.json();
+            setNumUsers(tweetsData.tweets.total);
+            setTweets(tweetsData.tweets.data);
+        }
+    };
+
+    // ツイート一覧をtweetsにセット
+    useEffect(() => {
+        getUsers().then(() => {
+            getTweets();
+        });
+    }, []);
+
+    // ページネーション時に、追加分を呼び出し
+    const handlePaginate = async (page) => {
+        const res = await fetch(`/tweets?page=${page}`);
+        if (res.status === 200) {
+            const tweetsData = await res.json();
+            setTweets(tweetsData.tweets.data);
+        }
+    };
+
+    const tweetItem = tweets.map((tweet) => {
+        // ツイートユーザーの情報を取得
+        const userData = users.find((data) => data.id === tweet.user_id);
+
+        return (
+            <li key={tweet.id}>
+                <div className="user__item-container">
+                    <Link to={`/tweet-${tweet.id}`}>
+                        <div className="d-flex px-2 py-4 w-100">
+                            <UserIcon
+                                iconData={{
+                                    icon: userData.profile_image_path,
+                                }}
+                            />
+                            <div className="ms-2 flex-grow-1">
+                                <div className="d-flex justify-content-between">
+                                    <UserName
+                                        nameData={{
+                                            screen_name: userData.screen_name,
+                                            user_name: userData.user_name,
+                                        }}
+                                    />
+                                </div>
+                                <div className="mt-1">
+                                    <p>{tweet.text}</p>
+                                </div>
+                            </div>
+                        </div>
+                    </Link>
+                </div>
+            </li>
+        );
+    });
+
+    return (
+        <div className="mt-4">
+            <div className="border">
+                <ul>{tweetItem}</ul>
+            </div>
+            <Pagenation
+                sum={numUsers}
+                per={10}
+                onChange={(e) => handlePaginate(e.page)}
+            />
+        </div>
+    );
+};

--- a/src/resources/js/components/page/TweetList.jsx
+++ b/src/resources/js/components/page/TweetList.jsx
@@ -10,14 +10,16 @@ export const TweetList = () => {
     const [tweets, setTweets] = useState([]);
     const [numUsers, setNumUsers] = useState(0);
 
+    // 認証ユーザー以外の全ユーザーを取得
     const getUsers = async () => {
         const res = await fetch("/users");
         if (res.status === 200) {
-            const firstPage = await res.json();
-            setUsers(firstPage.users.data);
+            const usersData = await res.json();
+            setUsers(usersData.users.data);
         }
     };
 
+    // １ページ目のツイートを取得
     const getTweets = async () => {
         const res = await fetch("/tweets?page=1");
         if (res.status === 200) {

--- a/src/resources/js/components/page/TweetList.jsx
+++ b/src/resources/js/components/page/TweetList.jsx
@@ -5,16 +5,19 @@ import { UserIcon } from "../parts/UserIcon";
 import { UserName } from "../parts/UserName";
 import { Pagenation } from "../parts/Pagenation";
 
-export const TweetList = () => {
+export const TweetList = (props) => {
+    const { currentPage, setCurrentPage } = props;
+
     const [users, setUsers] = useState([]);
     const [tweets, setTweets] = useState([]);
     const [numUsers, setNumUsers] = useState(0);
 
     // １ページ目のツイートを取得
     const getTweets = async () => {
-        const res = await fetch("/tweets?page=1");
+        const res = await fetch(`/tweets?page=${currentPage}`);
         if (res.status === 200) {
             const tweetsData = await res.json();
+            console.log("aa");
             setUsers(tweetsData.users);
             setNumUsers(tweetsData.tweets.total);
             setTweets(tweetsData.tweets.data);
@@ -22,18 +25,10 @@ export const TweetList = () => {
     };
 
     useEffect(() => {
+        console.log("useEffect");
+        console.log(currentPage);
         getTweets();
-    }, []);
-
-    // ページネーション時に、追加分を呼び出し
-    const handlePaginate = async (page) => {
-        if (page < 1) return;
-        const res = await fetch(`/tweets?page=${page}`);
-        if (res.status === 200) {
-            const tweetsData = await res.json();
-            setTweets(tweetsData.tweets.data);
-        }
-    };
+    }, [currentPage]);
 
     const tweetItem = tweets.map((tweet) => {
         // ツイートユーザーの情報を取得
@@ -79,7 +74,9 @@ export const TweetList = () => {
             <Pagenation
                 sum={numUsers}
                 per={10}
-                onChange={(e) => handlePaginate(e.page)}
+                currentPage={currentPage}
+                setCurrentPage={setCurrentPage}
+                onChange={(e) => setCurrentPage(e.page)}
             />
         </div>
     );

--- a/src/resources/js/components/page/TweetList.jsx
+++ b/src/resources/js/components/page/TweetList.jsx
@@ -10,20 +10,12 @@ export const TweetList = () => {
     const [tweets, setTweets] = useState([]);
     const [numUsers, setNumUsers] = useState(0);
 
-    // 認証ユーザー以外の全ユーザーを取得
-    const getUsers = async () => {
-        const res = await fetch("/users");
-        if (res.status === 200) {
-            const usersData = await res.json();
-            setUsers(usersData.users.data);
-        }
-    };
-
     // １ページ目のツイートを取得
     const getTweets = async () => {
         const res = await fetch("/tweets?page=1");
         if (res.status === 200) {
             const tweetsData = await res.json();
+            setUsers(tweetsData.users);
             setNumUsers(tweetsData.tweets.total);
             setTweets(tweetsData.tweets.data);
         }
@@ -31,9 +23,7 @@ export const TweetList = () => {
 
     // ツイート一覧をtweetsにセット
     useEffect(() => {
-        getUsers().then(() => {
-            getTweets();
-        });
+        getTweets();
     }, []);
 
     // ページネーション時に、追加分を呼び出し
@@ -48,6 +38,7 @@ export const TweetList = () => {
     const tweetItem = tweets.map((tweet) => {
         // ツイートユーザーの情報を取得
         const userData = users.find((data) => data.id === tweet.user_id);
+        console.log(userData);
 
         return (
             <li key={tweet.id}>
@@ -55,9 +46,11 @@ export const TweetList = () => {
                     <Link to={`/tweet/${tweet.id}`}>
                         <div className="d-flex px-2 py-4 w-100">
                             <UserIcon
-                                iconData={{
-                                    icon: userData.profile_image_path,
-                                }}
+                                iconData={
+                                    userData.profile_image_path
+                                        ? userData.profile_image_path
+                                        : "no-image.png"
+                                }
                             />
                             <div className="ms-2 flex-grow-1">
                                 <div className="d-flex justify-content-between">

--- a/src/resources/js/components/page/TweetList.jsx
+++ b/src/resources/js/components/page/TweetList.jsx
@@ -5,8 +5,8 @@ import { UserIcon } from "../parts/UserIcon";
 import { UserName } from "../parts/UserName";
 import { Pagenation } from "../parts/Pagenation";
 
-export const TweetList = (props) => {
-    const { currentPage, setCurrentPage } = props;
+export const TweetList = () => {
+    const [currentPage, setCurrentPage] = useState(1);
 
     const [users, setUsers] = useState([]);
     const [tweets, setTweets] = useState([]);

--- a/src/resources/js/components/page/TweetList.jsx
+++ b/src/resources/js/components/page/TweetList.jsx
@@ -21,13 +21,13 @@ export const TweetList = () => {
         }
     };
 
-    // ツイート一覧をtweetsにセット
     useEffect(() => {
         getTweets();
     }, []);
 
     // ページネーション時に、追加分を呼び出し
     const handlePaginate = async (page) => {
+        if (page < 1) return;
         const res = await fetch(`/tweets?page=${page}`);
         if (res.status === 200) {
             const tweetsData = await res.json();
@@ -38,7 +38,7 @@ export const TweetList = () => {
     const tweetItem = tweets.map((tweet) => {
         // ツイートユーザーの情報を取得
         const userData = users.find((data) => data.id === tweet.user_id);
-        console.log(userData);
+        // console.log(userData);
 
         return (
             <li key={tweet.id}>

--- a/src/resources/js/components/page/TweetList.jsx
+++ b/src/resources/js/components/page/TweetList.jsx
@@ -17,7 +17,6 @@ export const TweetList = (props) => {
         const res = await fetch(`/tweets?page=${currentPage}`);
         if (res.status === 200) {
             const tweetsData = await res.json();
-            console.log("aa");
             setUsers(tweetsData.users);
             setNumUsers(tweetsData.tweets.total);
             setTweets(tweetsData.tweets.data);
@@ -25,8 +24,6 @@ export const TweetList = (props) => {
     };
 
     useEffect(() => {
-        console.log("useEffect");
-        console.log(currentPage);
         getTweets();
     }, [currentPage]);
 

--- a/src/resources/js/components/page/TweetList.jsx
+++ b/src/resources/js/components/page/TweetList.jsx
@@ -50,7 +50,7 @@ export const TweetList = () => {
         return (
             <li key={tweet.id}>
                 <div className="user__item-container">
-                    <Link to={`/tweet-${tweet.id}`}>
+                    <Link to={`/tweet/${tweet.id}`}>
                         <div className="d-flex px-2 py-4 w-100">
                             <UserIcon
                                 iconData={{

--- a/src/resources/js/components/page/TweetList.jsx
+++ b/src/resources/js/components/page/TweetList.jsx
@@ -38,7 +38,6 @@ export const TweetList = () => {
     const tweetItem = tweets.map((tweet) => {
         // ツイートユーザーの情報を取得
         const userData = users.find((data) => data.id === tweet.user_id);
-        // console.log(userData);
 
         return (
             <li key={tweet.id}>

--- a/src/resources/js/components/page/UserList.jsx
+++ b/src/resources/js/components/page/UserList.jsx
@@ -92,11 +92,7 @@ export const UserList = () => {
                 <div className="user__item-container">
                     <Link to={`/profile/${item.id}`}>
                         <div className="d-flex px-2 py-4 w-100">
-                            <UserIcon
-                                iconData={{
-                                    icon: item.profile_image_path,
-                                }}
-                            />
+                            <UserIcon iconData={item.profile_image_path} />
                             <div className="ms-2 flex-grow-1">
                                 <div className="d-flex justify-content-between">
                                     <UserName

--- a/src/resources/js/components/page/UserList.jsx
+++ b/src/resources/js/components/page/UserList.jsx
@@ -90,7 +90,7 @@ export const UserList = () => {
         return (
             <li key={item.id}>
                 <div className="user__item-container">
-                    <Link to={`/profile-${item.id}`}>
+                    <Link to={`/profile/${item.id}`}>
                         <div className="d-flex px-2 py-4 w-100">
                             <UserIcon
                                 iconData={{

--- a/src/resources/js/components/page/UserList.jsx
+++ b/src/resources/js/components/page/UserList.jsx
@@ -15,9 +15,9 @@ export const UserList = () => {
         'meta[name="csrf-token"]'
     ).content;
 
-    // /authuser 認証ユーザーの情報取得
+    // 認証ユーザーの情報取得
     const getAuthUserData = async () => {
-        const res = await fetch("/authuser", {
+        const res = await fetch("/auth-user", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",

--- a/src/resources/js/components/page/UserProfile.jsx
+++ b/src/resources/js/components/page/UserProfile.jsx
@@ -120,13 +120,7 @@ export const UserProfile = () => {
                         <div className="w-100 d-flex justify-content-end">
                             {profileButton()}
                         </div>
-                        <UserIcon
-                            userList={false}
-                            iconData={{
-                                icon: user.icon,
-                                desc: user.iconDesc,
-                            }}
-                        />
+                        <UserIcon userList={false} iconData={user.icon} />
                     </div>
                     <div>
                         <UserName

--- a/src/resources/js/components/page/UserProfile.jsx
+++ b/src/resources/js/components/page/UserProfile.jsx
@@ -53,7 +53,7 @@ export const UserProfile = () => {
     }, []);
 
     const getUserProfile = async () => {
-        const res = await fetch(`/user-${id}`);
+        const res = await fetch(`/users/${id}`);
         if (res.status === 200) {
             const userProfile = await res.json();
             setIsFollowing(authUserFollows.includes(Number(id)));
@@ -86,7 +86,7 @@ export const UserProfile = () => {
     return (
         <div className="container-lg mt-5">
             <div className="border">
-                <div onClick={() => console.log(isFollowing)}>
+                <div>
                     <div className="d-flex p-1">
                         <Link to="/userlist">
                             <button className="btn">

--- a/src/resources/js/components/page/UserProfile.jsx
+++ b/src/resources/js/components/page/UserProfile.jsx
@@ -19,9 +19,9 @@ export const UserProfile = () => {
     const csrf_token = document.querySelector(
         'meta[name="csrf-token"]'
     ).content;
-    // /authuser 認証ユーザーの情報取得
+    // 認証ユーザーの情報取得
     const getAuthUserData = async () => {
-        const res = await fetch("/authuser", {
+        const res = await fetch("/auth-user", {
             method: "POST",
             headers: {
                 "Content-Type": "application/json",

--- a/src/resources/js/components/parts/Pagenation.jsx
+++ b/src/resources/js/components/parts/Pagenation.jsx
@@ -3,12 +3,7 @@ import React, { useEffect, useState } from "react";
 import "/css/pagenation.css";
 
 export const Pagenation = (props) => {
-    const [currentPage, setPage] = useState(0);
-
-    useEffect(() => {
-        props.onChange({ page: currentPage });
-    }, [currentPage]);
-
+    const { currentPage, setCurrentPage } = props;
     // ページネーションの総数
     const totalPage = Math.ceil(props.sum / props.per);
 
@@ -17,8 +12,7 @@ export const Pagenation = (props) => {
         if (currentPage === 1) {
             return;
         }
-
-        setPage(currentPage - 1);
+        setCurrentPage(currentPage - 1);
     };
 
     // ボタンで１ページ進む時
@@ -26,13 +20,12 @@ export const Pagenation = (props) => {
         if (currentPage === totalPage) {
             return;
         }
-
-        setPage(currentPage + 1);
+        setCurrentPage(currentPage + 1);
     };
 
     // ページ番号を直接クリックされたときの処理
     const handleMove = (page) => {
-        setPage(page);
+        setCurrentPage(page);
     };
 
     return (

--- a/src/resources/js/components/parts/UserIcon.jsx
+++ b/src/resources/js/components/parts/UserIcon.jsx
@@ -23,7 +23,7 @@ export const UserIcon = (props) => {
             <div className="w-100 h-100 overflow-hidden rounded-circle border">
                 <img
                     className="w-100 h-100"
-                    src={`/images/${props.iconData.icon}`}
+                    src={`/images/${props.iconData}`}
                     alt="ユーザアイコン"
                 />
             </div>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -27,7 +27,7 @@ Route::middleware('auth')->group(function () {
 
     Route::post('/follow-{userId}', [UserController::class, 'follow']);
     Route::post('/unfollow-{userId}', [UserController::class, 'unfollow']);
-    Route::post('/authuser', [UserController::class, 'getAuthuserInfo']);
+    Route::post('/auth-user', [UserController::class, 'getAuthuserInfo']);
 });
 
 Route::get('/{any}', function () {

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\TweetController;
 use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
@@ -20,6 +21,9 @@ Route::middleware('auth')->group(function () {
 
     Route::get('/count-follows/{userId}', [UserController::class, 'countFollows']);
     Route::get('/count-followers/{userId}', [UserController::class, 'countFollowers']);
+
+    Route::get('/tweets', [TweetController::class, 'index']);
+    Route::get('/tweet-{userId}', [TweetController::class, 'show']);
 
     Route::post('/follow-{userId}', [UserController::class, 'follow']);
     Route::post('/unfollow-{userId}', [UserController::class, 'unfollow']);

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -17,13 +17,13 @@ Auth::routes();
 
 Route::middleware('auth')->group(function () {
     Route::get('/users', [UserController::class, 'index']);
-    Route::get('/user-{userId}', [UserController::class, 'show']);
+    Route::get('/users/{userId}', [UserController::class, 'show']);
 
     Route::get('/count-follows/{userId}', [UserController::class, 'countFollows']);
     Route::get('/count-followers/{userId}', [UserController::class, 'countFollowers']);
 
     Route::get('/tweets', [TweetController::class, 'index']);
-    Route::get('/tweet-{userId}', [TweetController::class, 'show']);
+    Route::get('/tweets/{userId}', [TweetController::class, 'show']);
 
     Route::post('/follow-{userId}', [UserController::class, 'follow']);
     Route::post('/unfollow-{userId}', [UserController::class, 'unfollow']);


### PR DESCRIPTION
## 概要
ツイート一覧と詳細を取得してブラウザに表示
## 改修内容
- tweetsテーブルの作成
- ツイート内容取得するAPI作成
- ブラウザにツイート一覧と詳細を表示

### ツイート一覧(10件ずつ
![image](https://user-images.githubusercontent.com/49902457/175865673-885886fa-06a7-4477-bb4a-3193c61990d1.png)

### ツイート詳細
![image](https://user-images.githubusercontent.com/49902457/175862209-ac432aee-d458-40f8-bc3e-080626e59b25.png)


## 特に見てほしいところ
- `TweetList.jsx`・`TweetDetail.jsx`の書き方や命名
- `TweetController`のindexメソッド・showメソッド
